### PR TITLE
stackerr: annotate errors with source file and line number

### DIFF
--- a/pkg/stackerr/example_test.go
+++ b/pkg/stackerr/example_test.go
@@ -1,0 +1,42 @@
+package stackerr
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Examples are in their own file because their output has hard-coded line
+// numbers. This makes it easier to change/add other tests without constantly
+// breaking the examples.
+
+func Example_wrapped() {
+	// user := "gcurtis"
+	wrapped := Errorf("wrong password")
+	// err := Errorf("login %q: %w", user, wrapped)
+	fmt.Printf("error: %+v\n", wrapped)
+
+	// Output:
+	// error: login "gcurtis": wrong password
+	// example_test.go:15 login "gcurtis": wrong password
+	// example_test.go:14 wrong password
+}
+
+func Example_joined() {
+	errA := Errorf("error a")
+	err1 := Errorf("error 1: %w", errA)
+	err2 := Errorf("error 2")
+	err3 := Errorf("error 3")
+	err := Errorf("joined errors:\n%w", errors.Join(err1, err2, err3))
+	fmt.Printf("error: %+v\n", err)
+
+	// Output:
+	// error: joined errors:
+	// error 1: error a
+	// error 2
+	// error 3
+	// example_test.go:29 "joined errors:\nerror 1: error a\nerror 2\nerror 3"
+	// 	[0] example_test.go:26 error 1: error a
+	// 	    example_test.go:25 error a
+	// 	[1] example_test.go:27 error 2
+	// 	[2] example_test.go:28 error 3
+}

--- a/pkg/stackerr/example_test.go
+++ b/pkg/stackerr/example_test.go
@@ -10,10 +10,10 @@ import (
 // breaking the examples.
 
 func Example_wrapped() {
-	// user := "gcurtis"
+	user := "gcurtis"
 	wrapped := Errorf("wrong password")
-	// err := Errorf("login %q: %w", user, wrapped)
-	fmt.Printf("error: %+v\n", wrapped)
+	err := Errorf("login %q: %w", user, wrapped)
+	fmt.Printf("error: %+v\n", err)
 
 	// Output:
 	// error: login "gcurtis": wrong password

--- a/pkg/stackerr/stackerr.go
+++ b/pkg/stackerr/stackerr.go
@@ -1,0 +1,164 @@
+/*
+Package stackerr annotates errors with their source filename and line number.
+
+This package differs from other error packages in two ways:
+
+  - Errors provide the filename and line numbers that create or wrap errors.
+    They do not record a stack trace.
+  - It is not a replacement for the standard errors package.
+
+The Errorf function is the same as fmt.Errorf except that it also records the
+filename and line number of where it's called. When an Errorf error is formatted
+with a '+' flag ("%+s", "%+v", or "%+q") it prints its source file location:
+
+	err := Errorf("wrong password")
+	fmt.Printf("error: %+v\n", err)
+	// Output:
+	// error: wrong password
+	// /go/src/login.go:14 wrong password
+
+If it wraps another error, it also prints source information for other Errorf
+errors in its tree:
+
+	user := "gcurtis"
+	wrapped := Errorf("wrong password")
+	err := Errorf("login %q: %w", user, wrapped)
+	fmt.Printf("error: %+v\n", err)
+
+	// Output:
+	// error: login "gcurtis": wrong password
+	// /go/src/handler.go:176 login "gcurtis": wrong password
+	// /go/src/login.go:14 wrong password
+
+Note that the output is not a stack trace. It provides the location of the call
+to Errorf, not where the error returns up the stack. In some cases, seeing the
+lines that build the error chain is more accurate than a stack trace, but it
+also means that errors from other packages will not have location information.
+
+When using the [log] or [log/slog] packages, consider setting the
+[log.Llongfile] flag or [log/slog.HandlerOptions.AddSource] field, respectively,
+instead of using this package.
+*/
+package stackerr
+
+import (
+	"fmt"
+	"io"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+// Errorf is like fmt.Errorf, except it also records the source file and line
+// number that calls Errorf. Formatting the error with the fmt '+' flag prints
+// its source location. See the package documentation for details.
+func Errorf(format string, a ...any) error {
+	err := fmt.Errorf(format, a...)
+	switch t := err.(type) {
+	case interface{ Unwrap() error }:
+		werr := &wrapError{
+			srcError: srcError{msg: err.Error()},
+			err:      t.Unwrap(),
+		}
+		runtime.Callers(2, werr.pc[:])
+		return werr
+	case interface{ Unwrap() []error }:
+		werr := &wrapErrors{
+			srcError: srcError{msg: err.Error()},
+			errs:     t.Unwrap(),
+		}
+		runtime.Callers(2, werr.pc[:])
+		return werr
+	default:
+		serr := &srcError{msg: err.Error()}
+		runtime.Callers(2, serr.pc[:])
+		return serr
+	}
+}
+
+type srcError struct {
+	msg string
+	pc  [1]uintptr
+}
+
+func (e *srcError) Error() string                 { return e.msg }
+func (e *srcError) Frame() runtime.Frame          { fr, _ := runtime.CallersFrames(e.pc[:]).Next(); return fr }
+func (e *srcError) Format(f fmt.State, verb rune) { format(f, verb, e) }
+
+type wrapError struct {
+	srcError
+	err error
+}
+
+func (e *wrapError) Unwrap() error                 { return e.err }
+func (e *wrapError) Format(f fmt.State, verb rune) { format(f, verb, e) }
+
+type wrapErrors struct {
+	srcError
+	errs []error
+}
+
+func (e *wrapErrors) Unwrap() []error               { return e.errs }
+func (e *wrapErrors) Format(f fmt.State, verb rune) { format(f, verb, e) }
+
+func format(f fmt.State, verb rune, err error) {
+	fmt.Fprintf(f, fmt.FormatString(f, verb), err.Error())
+	if f.Flag('+') {
+		io.WriteString(f, "\n")
+		printChain(f, err, "")
+	}
+}
+
+func printChain(w io.Writer, err error, indent string) {
+	printFileLine(w, err, "")
+	for {
+		switch uw := err.(type) {
+		case interface{ Unwrap() error }:
+			err = uw.Unwrap()
+			if err == nil {
+				return
+			}
+		case interface{ Unwrap() []error }:
+			joined := uw.Unwrap()
+			if len(joined) == 0 {
+				return
+			}
+			width := len(strconv.Itoa(len(joined)))
+			indent := "\t" + strings.Repeat(" ", width+3)
+			for i, err := range uw.Unwrap() {
+				if err == nil {
+					continue
+				}
+				fmt.Fprintf(w, "\n\t[%*d] ", width, i)
+				printChain(w, err, indent)
+			}
+			return
+		default:
+			return
+		}
+		printFileLine(w, err, "\n"+indent)
+	}
+}
+
+var basePath = ""
+
+func printFileLine(w io.Writer, err error, prefix string) {
+	var fr runtime.Frame
+	if err, ok := err.(interface{ Frame() runtime.Frame }); ok {
+		fr = err.Frame()
+	}
+	if fr.Line == 0 {
+		return
+	}
+	if basePath != "" {
+		if rel, err := filepath.Rel(basePath, fr.File); err == nil {
+			fr.File = rel
+		}
+	}
+	msg := err.Error()
+	if !strconv.CanBackquote(strings.ReplaceAll(msg, "`", "\"")) {
+		msg = strconv.Quote(msg)
+	}
+	io.WriteString(w, prefix+fr.File+":"+strconv.Itoa(fr.Line)+" "+msg)
+}

--- a/pkg/stackerr/stackerr_test.go
+++ b/pkg/stackerr/stackerr_test.go
@@ -1,0 +1,268 @@
+package stackerr
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// Set the base path to the current working directory so that file paths in
+// the output are relative and predictable.
+func init() { basePath, _ = os.Getwd() }
+
+func TestNoWrap(t *testing.T) {
+	t.Run("%v", func(t *testing.T) {
+		msg := "test"
+		got := fmt.Sprintf("%v", Errorf("test"))
+		if got != msg {
+			t.Errorf("got %q, want %q", got, msg)
+		}
+	})
+	t.Run("%+v", func(t *testing.T) {
+		got := fmt.Sprintf("%+s", Errorf("test error"))
+		match, err := regexp.MatchString(strings.TrimSpace(`
+test error
+stackerr_test.go:\d+ test error
+`), got)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !match {
+			t.Errorf("regexp doesn't match output:\n%s", got)
+		}
+	})
+	t.Run("%s", func(t *testing.T) {
+		msg := "test"
+		got := fmt.Sprintf("%s", Errorf("test"))
+		if got != msg {
+			t.Errorf("got %q, want %q", got, msg)
+		}
+	})
+	t.Run("%+s", func(t *testing.T) {
+		got := fmt.Sprintf("%+s", Errorf("test error"))
+		match, err := regexp.MatchString(strings.TrimSpace(`
+test error
+stackerr_test.go:\d+ test error
+`), got)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !match {
+			t.Errorf("regexp doesn't match output:\n%s", got)
+		}
+	})
+	t.Run("%q", func(t *testing.T) {
+		got := fmt.Sprintf("%q", Errorf("test error"))
+		want := `"test error"`
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+	t.Run("%+q", func(t *testing.T) {
+		got := fmt.Sprintf("%+q", Errorf("test error"))
+		match, err := regexp.MatchString(strings.TrimSpace(`
+"test error"
+stackerr_test.go:\d+ test error
+`), got)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !match {
+			t.Errorf("regexp doesn't match output:\n%s", got)
+		}
+	})
+}
+
+func TestWrapped(t *testing.T) {
+	t.Run("%v", func(t *testing.T) {
+		wrapped := Errorf("wrapped")
+		got := fmt.Sprintf("%v", Errorf("test error: %w", wrapped))
+		want := "test error: wrapped"
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+	t.Run("%+v", func(t *testing.T) {
+		wrapped := Errorf("wrapped")
+		got := fmt.Sprintf("%+v", Errorf("test error: %w", wrapped))
+		match, err := regexp.MatchString(strings.TrimSpace(`
+test error: wrapped
+stackerr_test.go:\d+ test error: wrapped
+stackerr_test.go:\d+ wrapped
+`), got)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !match {
+			t.Errorf("regexp doesn't match output:\n%s", got)
+		}
+	})
+	t.Run("%v", func(t *testing.T) {
+		wrapped := Errorf("wrapped")
+		got := fmt.Sprintf("%v", Errorf("test error: %w", wrapped))
+		want := "test error: wrapped"
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+	t.Run("%+v", func(t *testing.T) {
+		wrapped := Errorf("wrapped")
+		got := fmt.Sprintf("%+v", Errorf("test error: %w", wrapped))
+		match, err := regexp.MatchString(strings.TrimSpace(`
+test error: wrapped
+stackerr_test.go:\d+ test error: wrapped
+stackerr_test.go:\d+ wrapped
+`), got)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !match {
+			t.Errorf("regexp doesn't match output:\n%s", got)
+		}
+	})
+	t.Run("%q", func(t *testing.T) {
+		wrapped := Errorf("wrapped")
+		got := fmt.Sprintf("%q", Errorf("test error: %w", wrapped))
+		want := `"test error: wrapped"`
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+	t.Run("%+q", func(t *testing.T) {
+		wrapped := Errorf("wrapped")
+		got := fmt.Sprintf("%+q", Errorf("test error: %w", wrapped))
+		match, err := regexp.MatchString(strings.TrimSpace(`
+"test error: wrapped"
+stackerr_test.go:\d+ test error: wrapped
+stackerr_test.go:\d+ wrapped
+`), got)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !match {
+			t.Errorf("regexp doesn't match output:\n%s", got)
+		}
+	})
+}
+
+func TestJoined(t *testing.T) {
+	t.Run("%v", func(t *testing.T) {
+		err1 := Errorf("err1")
+		err2 := Errorf("err2")
+		err3 := Errorf("err3")
+		got := fmt.Sprintf("%v", errors.Join(err1, err2, err3))
+		want := "err1\nerr2\nerr3"
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+	t.Run("%+v", func(t *testing.T) {
+		err1 := Errorf("err1")
+		err2 := Errorf("err2")
+		err3 := Errorf("err3")
+		got := fmt.Sprintf("%+v", Errorf("joined:\n%w", errors.Join(err1, err2, err3)))
+		match, err := regexp.MatchString(strings.TrimSpace(`
+joined:
+err1
+err2
+err3
+stackerr_test.go:\d+ "joined:\\nerr1\\nerr2\\nerr3"
+	\[0\] stackerr_test.go:\d+ err1
+	\[1\] stackerr_test.go:\d+ err2
+	\[2\] stackerr_test.go:\d+ err3
+`), got)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !match {
+			t.Errorf("regexp doesn't match output:\n%s", got)
+		}
+	})
+	t.Run("%s", func(t *testing.T) {
+		err1 := Errorf("err1")
+		err2 := Errorf("err2")
+		err3 := Errorf("err3")
+		got := fmt.Sprintf("%s", errors.Join(err1, err2, err3))
+		want := "err1\nerr2\nerr3"
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+	t.Run("%+s", func(t *testing.T) {
+		err1 := Errorf("err1")
+		err2 := Errorf("err2")
+		err3 := Errorf("err3")
+		got := fmt.Sprintf("%+s", Errorf("joined:\n%w", errors.Join(err1, err2, err3)))
+		match, err := regexp.MatchString(strings.TrimSpace(`
+joined:
+err1
+err2
+err3
+stackerr_test.go:\d+ "joined:\\nerr1\\nerr2\\nerr3"
+	\[0\] stackerr_test.go:\d+ err1
+	\[1\] stackerr_test.go:\d+ err2
+	\[2\] stackerr_test.go:\d+ err3
+`), got)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !match {
+			t.Errorf("regexp doesn't match output:\n%s", got)
+		}
+	})
+	t.Run("%q", func(t *testing.T) {
+		err1 := Errorf("err1")
+		err2 := Errorf("err2")
+		err3 := Errorf("err3")
+		got := fmt.Sprintf("%q", Errorf("joined:\n%w", errors.Join(err1, err2, err3)))
+		want := `"joined:\nerr1\nerr2\nerr3"`
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+	t.Run("%+q", func(t *testing.T) {
+		err1 := Errorf("err1")
+		err2 := Errorf("err2")
+		err3 := Errorf("err3")
+		got := fmt.Sprintf("%+q", Errorf("joined:\n%w", errors.Join(err1, err2, err3)))
+		match, err := regexp.MatchString(strings.TrimSpace(`
+"joined:\\nerr1\\nerr2\\nerr3"
+stackerr_test.go:\d+ "joined:\\nerr1\\nerr2\\nerr3"
+	\[0\] stackerr_test.go:\d+ err1
+	\[1\] stackerr_test.go:\d+ err2
+	\[2\] stackerr_test.go:\d+ err3
+`), got)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !match {
+			t.Errorf("regexp doesn't match output:\n%s", got)
+		}
+	})
+}
+
+func TestIs(t *testing.T) {
+	wrapped := Errorf("wrapped")
+	err := Errorf("error: %w", wrapped)
+	if !errors.Is(err, wrapped) {
+		t.Errorf("error %q doesn't unwrap to %q", err, wrapped)
+	}
+
+	wrapped = os.ErrNotExist
+	err = Errorf("error: %w", wrapped)
+	if !errors.Is(err, wrapped) {
+		t.Errorf("error %q doesn't unwrap to %q", err, wrapped)
+	}
+}
+
+func TestAs(t *testing.T) {
+	var unwrapped *os.PathError
+	wrapped := &os.PathError{Op: "test", Path: "/test/path", Err: fmt.Errorf("error")}
+	err := Errorf("error: %w", wrapped)
+	if !errors.As(err, &unwrapped) {
+		t.Errorf("error %q doesn't unwrap as %T", err, unwrapped)
+	}
+}


### PR DESCRIPTION
I wasn't entirely sure which directory this should go under. Let me know if it should be moved.

A more basic version of pkg/errors that offers a `fmt.Errorf` function which can record the filename and line number of where it was called.

Example:

	user := "gcurtis"
	wrapped := stackerr.Errorf("wrong password")
	err := stackerr.Errorf("login %q: %w", user, wrapped)
	fmt.Printf("error: %+v\n", err)

	// Output:
	// error: login "gcurtis": wrong password
	// /go/src/handler.go:176 login "gcurtis": wrong password
	// /go/src/login.go:14 wrong password
