### PR TITLE
[pkg] Add Clear to filecache and move cachehash and redact from devbox

### DIFF
--- a/pkg/cachehash/hash.go
+++ b/pkg/cachehash/hash.go
@@ -1,0 +1,90 @@
+// Package cachehash generates non-cryptographic cache keys.
+//
+// The functions in this package make no guarantees about the underlying hashing
+// algorithm. It should only be used for caching, where it's ok if the hash for
+// a given input changes.
+package cachehash
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"hash"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/gosimple/slug"
+	"go.jetpack.io/pkg/redact"
+)
+
+// Bytes returns a hex-encoded hash of b.
+func Bytes(b []byte) string {
+	h := newHash()
+	h.Write(b)
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// Bytes6 returns the first 6 characters of the hash of b.
+func Bytes6(b []byte) string {
+	hash := Bytes(b)
+	return hash[:min(len(hash), 6)]
+}
+
+// File returns a hex-encoded hash of a file's contents.
+func File(path string) (string, error) {
+	f, err := os.Open(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	h := newHash()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// JSON marshals a to JSON and returns its hex-encoded hash.
+func JSON(a any) (string, error) {
+	b, err := json.Marshal(a)
+	if err != nil {
+		return "", redact.Errorf("marshal to json for hashing: %v", err)
+	}
+	return Bytes(b), nil
+}
+
+// JSONFile compacts the JSON in a file and returns its hex-encoded hash.
+func JSONFile(path string) (string, error) {
+	b, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	buf := &bytes.Buffer{}
+	if err := json.Compact(buf, b); err != nil {
+		return "", redact.Errorf("compact json for hashing: %v", err)
+	}
+	return Bytes(buf.Bytes()), nil
+}
+
+func newHash() hash.Hash { return sha256.New() }
+
+// Slug returns a deterministic URL slug version of the string. With the
+// following characteristics:
+//
+// * A 6 character hash is appended to avoid collisions
+// * Trims the slug to last 50 characters
+// * Removes any prefixed hashes to ensure first character is alphanumeric
+func Slug(s string) string {
+	s = slug.Make(s) + "-" + Bytes6([]byte(s))
+	return strings.TrimPrefix(s[max(0, len(s)-50):], "-")
+}

--- a/pkg/cachehash/hash_test.go
+++ b/pkg/cachehash/hash_test.go
@@ -1,0 +1,164 @@
+//nolint:varnamelen
+package cachehash
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestFile(t *testing.T) {
+	dir := t.TempDir()
+
+	ab := filepath.Join(dir, "ab.json")
+	err := os.WriteFile(ab, []byte(`{"a":"\n","b":"\u000A"}`), 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ba := filepath.Join(dir, "ba.json")
+	err = os.WriteFile(ba, []byte(`{"b":"\n","a":"\u000A"}`), 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	abHash, err := File(ab)
+	if err != nil {
+		t.Errorf("got File(ab) error: %v", err)
+	}
+	baHash, err := File(ba)
+	if err != nil {
+		t.Errorf("got File(ba) error: %v", err)
+	}
+	if abHash == baHash {
+		t.Errorf("got (File(%q) = %q) == (File(%q) = %q), want different hashes", ab, abHash, ba, baHash)
+	}
+}
+
+func TestFileNotExist(t *testing.T) {
+	t.TempDir()
+	hash, err := File(t.TempDir() + "/notafile")
+	if err != nil {
+		t.Errorf("got error: %v", err)
+	}
+	if hash != "" {
+		t.Errorf("got non-empty hash %q", hash)
+	}
+}
+
+func TestJSON(t *testing.T) {
+	a := struct{ A, B string }{"a", "b"}
+	aHash, err := JSON(a)
+	if err != nil {
+		t.Errorf("got JSON(%#q) error: %v", a, err)
+	}
+	if aHash == "" {
+		t.Errorf(`got JSON(%#q) == ""`, a)
+	}
+
+	b := map[string]string{"A": "a", "B": "b"}
+	bHash, err := JSON(b)
+	if err != nil {
+		t.Errorf("got JSON(%#q) error: %v", b, err)
+	}
+	if bHash == "" {
+		t.Errorf(`got JSON(%#q) == ""`, b)
+	}
+	if aHash != bHash {
+		t.Errorf("got (JSON(%#q) = %q) != (JSON(%#q) = %q), want equal hashes", a, aHash, b, bHash)
+	}
+}
+
+func TestJSONUnsupportedType(t *testing.T) {
+	j := struct{ C chan int }{}
+	_, err := JSON(j)
+	if err == nil {
+		t.Error("got nil error for struct with channel field")
+	}
+}
+
+func TestJSONFile(t *testing.T) {
+	dir := t.TempDir()
+
+	compact := filepath.Join(dir, "compact.json")
+	err := os.WriteFile(compact, []byte(`{"key":"value"}`), 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	space := filepath.Join(dir, "space.json")
+	err = os.WriteFile(space, []byte(`{ "key": "value" }`), 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	compactHash, err := JSONFile(compact)
+	if err != nil {
+		t.Errorf("got JSONFile(ab) error: %v", err)
+	}
+	spaceHash, err := JSONFile(space)
+	if err != nil {
+		t.Errorf("got JSONFile(ba) error: %v", err)
+	}
+	if compactHash != spaceHash {
+		t.Errorf("got (JSONFile(%q) = %q) != (JSONFile(%q) = %q), want equal hashes", compact, compactHash, space, spaceHash)
+	}
+}
+
+func TestJSONFileNotExist(t *testing.T) {
+	t.TempDir()
+	hash, err := JSONFile(t.TempDir() + "/notafile")
+	if err != nil {
+		t.Errorf("got error: %v", err)
+	}
+	if hash != "" {
+		t.Errorf("got non-empty hash %q", hash)
+	}
+}
+
+func TestSlug(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"basic", "HelloWorld", "helloworld-872e4e"},
+		{"special chars", "Hello, World!", "hello-world-dffd60"},
+		{"empty string", "", "e3b0c4"},
+		{"leading special char", "@hello", "athello-8f8a2f"},
+		{
+			"url",
+			"https://example.com/path?query=foo.bar",
+			"https-example-com-path-query-foo-bar-3e60ff",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := Slug(c.input)
+			if got != c.expected {
+				t.Errorf("Slug(%q) == %q, want %q", c.input, got, c.expected)
+			}
+		})
+	}
+
+	// test that 2 similar strings have different slugs
+	s1 := "Hello, World!"
+	s2 := "Hello, World"
+	if Slug(s1) == Slug(s2) {
+		t.Errorf("Slug(%q) == Slug(%q), want different slugs", s1, s2)
+	}
+
+	// Test that 2 super long truncated strings have the same slug
+	s3 := "	" + strings.Repeat("a", 1000)
+	s4 := "	" + strings.Repeat("a", 1000)
+	if Slug(s3) != Slug(s4) {
+		t.Errorf("Slug(%q) != Slug(%q), want same slug", s3, s4)
+	}
+
+	// Test that 2 super long strings have different slugs
+	s5 := strings.Repeat("a", 1000)
+	s6 := strings.Repeat("a", 1000) + "b"
+	if Slug(s5) == Slug(s6) {
+		t.Errorf("Slug(%q) == Slug(%q), want different slugs", s5, s6)
+	}
+}

--- a/pkg/filecache/filecache.go
+++ b/pkg/filecache/filecache.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"go.jetpack.io/pkg/cachehash"
 )
 
 var NotFound = errors.New("not found")
@@ -130,6 +131,10 @@ func (c *Cache[T]) GetOrSetWithTime(
 	return val, c.SetWithTime(key, val, t)
 }
 
+func (c *Cache[T]) Clear() error {
+	return errors.WithStack(os.RemoveAll(filepath.Join(c.cacheDir, c.domain)))
+}
+
 // IsCacheMiss returns true if the error is NotFound or Expired.
 func IsCacheMiss(err error) bool {
 	return errors.Is(err, NotFound) || errors.Is(err, Expired)
@@ -138,5 +143,5 @@ func IsCacheMiss(err error) bool {
 func (c *Cache[T]) filename(key string) string {
 	dir := filepath.Join(c.cacheDir, c.domain)
 	_ = os.MkdirAll(dir, 0755)
-	return filepath.Join(dir, key)
+	return filepath.Join(dir, cachehash.Slug(key))
 }

--- a/pkg/redact/redact.go
+++ b/pkg/redact/redact.go
@@ -1,0 +1,241 @@
+// Copyright 2024 Jetify Inc. and contributors. All rights reserved.
+// Use of this source code is governed by the license in the LICENSE file.
+
+// Package redact implements functions to redact sensitive information from
+// errors.
+//
+// Redacting an error replaces its message with a placeholder while still
+// maintaining wrapped errors:
+//
+//	wrapped := errors.New("not found")
+//	name := "Alex"
+//	err := fmt.Errorf("error getting user %s: %w", name, wrapped)
+//
+//	fmt.Println(err)
+//	// error getting user Alex: not found
+//
+//	fmt.Println(Error(err))
+//	// <redacted *fmt.wrapError>: <redacted *errors.errorString>
+//
+// If an error implements a Redact() string method, then it is said to be
+// redactable. A redactable error defines an alternative message for its
+// redacted form:
+//
+//	type userErr struct{ name string }
+//
+//	func (e *userErr) Error() string {
+//		return fmt.Sprintf("user %s not found", e.name)
+//	}
+//
+//	func (e *userErr) Redact() string {
+//		return fmt.Sprintf("user %x not found", sha256.Sum256([]byte(e.name)))
+//	}
+//
+//	func main() {
+//		err := &userErr{name: "Alex"}
+//		fmt.Println(err)
+//		// user Alex not found
+//
+//		fmt.Println(Error(err))
+//		// user db74c940d447e877d119df613edd2700c4a84cd1cf08beb7cbc319bcfaeab97a not found
+//	}
+//
+// The [Errorf] function creates redactable errors that retain their literal
+// format text, but redact any arguments. The format string spec is identical
+// to that of [fmt.Errorf]. Calling [Safe] on an [Errorf] argument will include
+// it in the redacted message.
+//
+//	name := "Alex"
+//	id := 5
+//	err := Errorf("error getting user %s with ID %d", name, Safe(id))
+//
+//	fmt.Println(err)
+//	// error getting user Alex with ID 5
+//
+//	fmt.Println(Error(err))
+//	// error getting user <redacted string> with ID 5
+//
+//nolint:errorlint
+package redact
+
+import (
+	"errors"
+	"fmt"
+	"runtime"
+)
+
+// Error returns a redacted error that wraps err. If err has a Redact() string
+// method, then Error uses it for the redacted error message. Otherwise, Error
+// recursively redacts each wrapped error, joining them with ": " to create the
+// final error message. If it encounters an error that has a Redact() method,
+// then it appends the result of Redact() to the message and stops unwrapping.
+func Error(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	switch t := err.(type) {
+	case *redactedError:
+		// Don't redact an already redacted error, otherwise its redacted message
+		// will be replaced with a placeholder.
+		return err
+	case redactor:
+		return &redactedError{
+			msg:     t.Redact(),
+			wrapped: err,
+		}
+	default:
+		msg := placeholder(err)
+		wrapped := err
+		for {
+			wrapped = errors.Unwrap(wrapped)
+			if wrapped == nil {
+				break
+			}
+			if redactor, ok := wrapped.(redactor); ok {
+				msg += ": " + redactor.Redact()
+				break
+			}
+			msg += ": " + placeholder(wrapped)
+		}
+		return &redactedError{
+			msg:     msg,
+			wrapped: err,
+		}
+	}
+}
+
+// Errorf creates a redactable error that has an error string identical to that
+// of a [fmt.Errorf] error. Calling [Redact] on the result will redact all
+// format arguments from the error message instead of redacting the entire
+// string.
+//
+// When redacting the error string, Errorf replaces arguments that implement a
+// Redact() string method with the result of that method. To include an
+// argument as-is in the redacted error, first call [Safe]. For example:
+//
+//	username := "bob"
+//	Errorf("cannot find user %s", username).Error()
+//	// cannot find user <redacted string>
+//
+//	Errorf("cannot find user %s", Safe(username)).Error()
+//	// cannot find user bob
+func Errorf(format string, a ...any) error {
+	// Capture a stack trace.
+	safeErr := &safeError{
+		callers: make([]uintptr, 32),
+	}
+	n := runtime.Callers(2, safeErr.callers)
+	safeErr.callers = safeErr.callers[:n]
+
+	// Create the "normal" unredacted error. We need to remove the safe wrapper
+	// from any args so that fmt.Errorf can detect and format their type
+	// correctly.
+	args := make([]any, len(a))
+	for i := range a {
+		if safe, ok := a[i].(safe); ok {
+			args[i] = safe.a
+		} else {
+			args[i] = a[i]
+		}
+	}
+	safeErr.err = fmt.Errorf(format, args...)
+
+	// Now create the redacted error by replacing all args with their redacted
+	// version or by inserting a placeholder if the arg can't be redacted.
+	for i := range a {
+		switch t := a[i].(type) {
+		case safe:
+			args[i] = t.a
+		case error:
+			args[i] = Error(t)
+		case redactor:
+			args[i] = formatter(t.Redact())
+		default:
+			args[i] = formatter(placeholder(t))
+		}
+	}
+	safeErr.redacted = fmt.Errorf(format, args...)
+	return safeErr
+}
+
+// redactor defines the Redact interface for types that can format themselves
+// in redacted errors.
+type redactor interface {
+	Redact() string
+}
+
+// safe wraps a value that is marked as safe for including in a redacted error.
+type safe struct{ a any }
+
+// Safe marks a value as safe for including in a redacted error.
+func Safe(a any) any {
+	return safe{a}
+}
+
+// safeError is an error that can redact its message.
+type safeError struct {
+	err      error
+	redacted error
+	callers  []uintptr
+}
+
+func (e *safeError) Error() string  { return e.err.Error() }
+func (e *safeError) Redact() string { return e.redacted.Error() }
+func (e *safeError) Unwrap() error  { return e.err }
+
+func (e *safeError) StackTrace() []runtime.Frame {
+	if len(e.callers) == 0 {
+		return nil
+	}
+	frameIter := runtime.CallersFrames(e.callers)
+	frames := make([]runtime.Frame, 0, len(e.callers))
+	for {
+		frame, more := frameIter.Next()
+		frames = append(frames, frame)
+		if !more {
+			break
+		}
+	}
+	return frames
+}
+
+func (e *safeError) Format(f fmt.State, verb rune) {
+	switch verb {
+	case 'v', 's':
+		f.Write([]byte(e.Error()))
+		if f.Flag('+') {
+			for _, fr := range e.StackTrace() {
+				fmt.Fprintf(f, "\n%s\n\t%s:%d", fr.Function, fr.File, fr.Line)
+			}
+			return
+		}
+	case 'q':
+		fmt.Fprintf(f, "%q", e.Error())
+	}
+}
+
+// redactedError is an error containing a redacted message. It is usually the
+// result of calling Error(safeError).
+type redactedError struct {
+	msg     string
+	wrapped error
+}
+
+func (e *redactedError) Error() string { return e.msg }
+func (e *redactedError) Unwrap() error { return e.wrapped }
+
+// formatter allows a string to be formatted by any fmt verb.
+// For example, fmt.Sprintf("%d", formatter("100")) will return "100" without
+// an error.
+type formatter string
+
+func (f formatter) Format(s fmt.State, verb rune) {
+	s.Write([]byte(f))
+}
+
+// placeholder generates a placeholder string for values that don't satisfy
+// redactor.
+func placeholder(a any) string {
+	return fmt.Sprintf("<redacted %T>", a)
+}

--- a/pkg/redact/redact_test.go
+++ b/pkg/redact/redact_test.go
@@ -1,0 +1,301 @@
+// Copyright 2024 Jetify Inc. and contributors. All rights reserved.
+// Use of this source code is governed by the license in the LICENSE file.
+
+//nolint:errorlint
+package redact
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func ExampleError() {
+	// Each error string in a chain of wrapped errors is redacted with a
+	// placeholder describing the error's type.
+	wrapped := errors.New("not found")
+	name := "Alex"
+	err := fmt.Errorf("error getting user %s: %w", name, wrapped)
+
+	fmt.Println("Normal:", err)
+	fmt.Println("Redacted:", Error(err))
+	// Output:
+	// Normal: error getting user Alex: not found
+	// Redacted: <redacted *fmt.wrapError>: <redacted *errors.errorString>
+}
+
+func ExampleErrorf() {
+	// Errors created with Errorf are redacted by omitting any arguments not
+	// marked as safe. The literal portion of the format string is kept.
+	wrapped := errors.New("not found")
+	name := "Alex"
+	id := 5
+	err := Errorf("error getting user %s with ID %d: %w", name, Safe(id), wrapped)
+
+	fmt.Println("Normal:", err)
+	fmt.Println("Redacted:", Error(err))
+	// Output:
+	// Normal: error getting user Alex with ID 5: not found
+	// Redacted: error getting user <redacted string> with ID 5: <redacted *errors.errorString>
+}
+
+func ExampleError_wrapped() {
+	// If an error wraps another, then redacting it results in a message with the
+	// redacted version of each error in the chain up until the first redactable
+	// error.
+	name := "Alex"
+	err := fmt.Errorf("fatal error: %w",
+		Errorf("error getting user %s: %w", name,
+			errors.New("not found")))
+
+	fmt.Println("Normal:", err)
+	fmt.Println("Redacted:", Error(err))
+	// Output:
+	// Normal: fatal error: error getting user Alex: not found
+	// Redacted: <redacted *fmt.wrapError>: error getting user <redacted string>: <redacted *errors.errorString>
+}
+
+func TestNil(t *testing.T) {
+	checkUnredactedError(t, nil, "<nil>")
+	checkRedactedError(t, nil, "<nil>")
+}
+
+func TestSimple(t *testing.T) {
+	err := errors.New("simple")
+	checkUnredactedError(t, err, "simple")
+	checkRedactedError(t, err, "<redacted *errors.errorString>")
+}
+
+func TestSimpleWrapSimple(t *testing.T) {
+	wrapped := errors.New("error 2")
+	err := fmt.Errorf("error 1: %w", wrapped)
+	checkUnredactedError(t, err, "error 1: error 2")
+	checkRedactedError(t, err, "<redacted *fmt.wrapError>: <redacted *errors.errorString>")
+	if !errors.Is(err, wrapped) {
+		t.Error("got errors.Is(err, wrapped) == false")
+	}
+}
+
+func TestRedactor(t *testing.T) {
+	err := &testRedactor{msg: "sensitive", redactedMsg: "safe"}
+	checkUnredactedError(t, err, "sensitive")
+	checkRedactedError(t, err, "safe")
+}
+
+func TestRedactorWrapRedactor(t *testing.T) {
+	wrapped := &testRedactor{
+		msg:         "wrapped sensitive",
+		redactedMsg: "wrapped safe",
+	}
+	err := &testRedactor{
+		msg:         "sensitive",
+		redactedMsg: "safe",
+		err:         wrapped,
+	}
+	checkUnredactedError(t, err, "sensitive")
+	checkRedactedError(t, err, "safe")
+	if !errors.Is(err, wrapped) {
+		t.Error("got errors.Is(err, wrapped) == false")
+	}
+}
+
+func TestSimpleWrapRedactor(t *testing.T) {
+	wrapped := &testRedactor{
+		msg:         "wrapped sensitive",
+		redactedMsg: "wrapped safe",
+	}
+	err := fmt.Errorf("error: %w", wrapped)
+	checkUnredactedError(t, err, "error: wrapped sensitive")
+	checkRedactedError(t, err, "<redacted *fmt.wrapError>: wrapped safe")
+	if !errors.Is(err, wrapped) {
+		t.Error("got errors.Is(err, wrapped) == false")
+	}
+}
+
+func TestNestedWrapRedactor(t *testing.T) {
+	nestedWrapped := &testRedactor{
+		msg:         "wrapped sensitive",
+		redactedMsg: "wrapped safe",
+	}
+	wrapped := fmt.Errorf("error 2: %w", nestedWrapped)
+	err := fmt.Errorf("error 1: %w", wrapped)
+	checkUnredactedError(t, err, "error 1: error 2: wrapped sensitive")
+	checkRedactedError(t, err, "<redacted *fmt.wrapError>: <redacted *fmt.wrapError>: wrapped safe")
+	if !errors.Is(err, wrapped) {
+		t.Error("got errors.Is(err, wrapped) == false")
+	}
+	if !errors.Is(err, nestedWrapped) {
+		t.Error("got errors.Is(err, nestedWrapped) == false")
+	}
+}
+
+func TestErrorf(t *testing.T) {
+	err := Errorf("quoted = %q, quotedSafe = %q, int = %d, intSafe = %d",
+		"sensitive", Safe("safe"),
+		123, Safe(789),
+	)
+	checkUnredactedError(t, err, `quoted = "sensitive", quotedSafe = "safe", int = 123, intSafe = 789`)
+	checkRedactedError(t, err, `quoted = <redacted string>, quotedSafe = "safe", int = <redacted int>, intSafe = 789`)
+
+	// Redact again to check that we don't wipe out the already-redacted message.
+	checkRedactedError(t, Error(err), `quoted = <redacted string>, quotedSafe = "safe", int = <redacted int>, intSafe = 789`)
+}
+
+func TestErrorfWrapErrorf(t *testing.T) {
+	wrapped := Errorf("wrapped string = %s, wrapped safe string = %s", "sensitive", Safe("safe"))
+	err := Errorf("error: %w", wrapped)
+	checkUnredactedError(t, err, "error: wrapped string = sensitive, wrapped safe string = safe")
+	checkRedactedError(t, err, "error: wrapped string = <redacted string>, wrapped safe string = safe")
+}
+
+func TestErrorfAs(t *testing.T) {
+	wrapped := &customError{
+		msg:   "sensitive",
+		value: "value",
+	}
+	err := Errorf("error: %w", wrapped)
+	checkUnredactedError(t, err, "error: sensitive")
+	checkRedactedError(t, err, "error: <redacted *redact.customError>")
+
+	var unwrapped *customError
+	if !errors.As(err, &unwrapped) {
+		t.Error("got errors.As(err, unwrapped) == false")
+	}
+	if unwrapped.value != wrapped.value {
+		t.Error("got unwrapped.value != wrapped.value")
+	}
+
+	var unwrappedRedacted *customError
+	if !errors.As(Error(err), &unwrappedRedacted) {
+		t.Error("got errors.As(Error(err), &unwrappedRedacted) == false")
+	}
+	if unwrappedRedacted.value != wrapped.value {
+		t.Error("got unwrappedRedacted.value != wrapped.value")
+	}
+}
+
+func TestErrorfRedactableArg(t *testing.T) {
+	err := Errorf("%d", redactableInt(123))
+	checkUnredactedError(t, err, "123")
+	checkRedactedError(t, err, "0")
+}
+
+func TestErrorFormat(t *testing.T) {
+	// Capture the first line of output as the error message and all following
+	// lines as the stack trace.
+	re := regexp.MustCompile(`(.+)?((?s)
+.+/redact.TestErrorFormat
+	.+/redact/redact_test.go:\d+
+.*
+runtime.goexit
+	.+:\d+.*)?`)
+
+	cases := []struct {
+		format    string
+		err       error
+		wantMsg   string
+		wantStack bool
+	}{
+		{"%v", Errorf("error %%v"), "error %v", false},
+		{"%+v", Errorf("error %%+v"), "error %+v", true},
+		{"%s", Errorf("error %%s"), "error %s", false},
+		{"%+s", Errorf("error %%+s"), "error %+s", true},
+		{"%q", Errorf("error %%q"), `"error %q"`, false},
+	}
+	for _, test := range cases {
+		t.Run(test.format, func(t *testing.T) {
+			got := fmt.Sprintf(test.format, test.err)
+			groups := re.FindStringSubmatch(got)
+			if groups == nil {
+				t.Fatal("formatted error doesn't match regexp")
+			}
+			t.Logf("got formatted stack trace:\n%q", got)
+			if got := groups[1]; got != test.wantMsg {
+				t.Errorf("got error message %q, want %q", got, test.wantMsg)
+			}
+			if test.wantStack && (len(groups) < 3 || groups[2] == "") {
+				t.Error("got formatted error without stack trace, wanted with stack trace")
+			} else if !test.wantStack && len(groups) > 2 && groups[2] != "" {
+				t.Error("got formatted error with stack trace, wanted without stack trace")
+			}
+		})
+	}
+}
+
+func TestStackTrace(t *testing.T) {
+	err := Errorf("error")
+	stack := err.(interface{ StackTrace() []runtime.Frame }).StackTrace()
+	if len(stack) == 0 {
+		t.Fatal("got empty stack trace")
+	}
+	stackTrace := "got stack trace:\n"
+	for _, frame := range stack {
+		stackTrace += fmt.Sprintf("%v\n", frame)
+	}
+	t.Log(stackTrace)
+
+	if !strings.HasSuffix(stack[0].Function, t.Name()) {
+		t.Errorf("got stack starting with function name %q, want function ending with test name %q",
+			stack[0].Function, t.Name())
+	}
+	lastFrame := stack[len(stack)-1]
+	wantFrame := "runtime.goexit"
+	if lastFrame.Function != wantFrame {
+		t.Errorf("got stack ending with function name %q, want function name %q",
+			lastFrame.Function, wantFrame)
+	}
+}
+
+func TestMissingStackTrace(t *testing.T) {
+	var err interface{ StackTrace() []runtime.Frame } = &safeError{}
+	stack := err.StackTrace()
+	if stack != nil {
+		t.Errorf("got stack with length %d, want nil", len(stack))
+	}
+}
+
+type testRedactor struct {
+	msg         string
+	redactedMsg string
+	err         error
+}
+
+func (e *testRedactor) Error() string  { return e.msg }
+func (e *testRedactor) Redact() string { return e.redactedMsg }
+func (e *testRedactor) Unwrap() error  { return e.err }
+
+type customError struct {
+	msg   string
+	value string
+}
+
+func (e *customError) Error() string {
+	return e.msg
+}
+
+type redactableInt int
+
+func (r redactableInt) Redact() string {
+	return "0"
+}
+
+func checkUnredactedError(t *testing.T, got error, wantMsg string) {
+	t.Helper()
+
+	gotMsg := fmt.Sprint(got)
+	if gotMsg != wantMsg {
+		t.Errorf("got wrong unredacted error:\ngot:  %q\nwant: %q", gotMsg, wantMsg)
+	}
+}
+
+func checkRedactedError(t *testing.T, got error, wantMsg string) {
+	t.Helper()
+
+	gotMsg := fmt.Sprint(Error(got))
+	if gotMsg != wantMsg {
+		t.Errorf("got wrong redacted error:\ngot:  %q\nwant: %q", gotMsg, wantMsg)
+	}
+}


### PR DESCRIPTION
## Summary

* Adds filecache.Clear()
* Turns keys into slugs to make sure they can be used as filenames safely. 
* Brings cachehash and redact from devbox. Not 100% sure how to keep authorship credit on these :( 

## How was it tested?

Existing tests