### PR TITLE
README update: C# firenero/typeid compliance with v0.3.0

### DIFF
--- a/typeid/typeid/README.md
+++ b/typeid/typeid/README.md
@@ -55,7 +55,7 @@ Latest spec version: v0.3.0
 | ------------------------------------------------------------- | ----------------------------------------------------------------------------------------- | ------------------ |
 | [C# (.Net)](https://github.com/TenCoKaciStromy/typeid-dotnet) | [@TenCoKaciStromy](https://github.com/TenCoKaciStromy)                                    | v0.2 on 2023-06-30 |
 | [C# (.Net Standard 2.1)](https://github.com/cbuctok/typeId)   | [@cbuctok](https://github.com/cbuctok)                                                    | v0.2 on 2023-07-03 |
-| [C# (.NET)](https://github.com/firenero/TypeId)               | [@firenero](https://github.com/firenero)                                                  | v0.2 on 2023-07-15 |
+| [C# (.NET)](https://github.com/firenero/TypeId)               | [@firenero](https://github.com/firenero)                                                  | v0.3 on 2024-04-15 |
 | [Dart](https://github.com/TBD54566975/typeid-dart)            | [@mistermoe](https://github.com/mistermoe) [@tbd54566975](https://github.com/tbd54566975) | v0.2 on 2024-03-25 |
 | [Elixir](https://github.com/sloanelybutsurely/typeid-elixir)  | [@sloanelybutsurely](https://github.com/sloanelybutsurely)                                | v0.2 on 2023-07-02 |
 | [Haskell](https://github.com/MMZK1526/mmzk-typeid)            | [@MMZK1526](https://github.com/MMZK1526)                                                  | v0.2 on 2023-07-07 |


### PR DESCRIPTION
## Summary

Updating the README to notify that [firenero/typeid](https://github.com/firenero/TypeId) implementation is now compliant with spec v0.3.0

## How was it tested?

Adjusted test cases to spec v0.3.0