### PR TITLE
[typeid-js] Add support for spec 0.3 (underscores in type)

### DIFF
--- a/typeid/typeid-js/.gitignore
+++ b/typeid/typeid-js/.gitignore
@@ -8,3 +8,4 @@ build/**
 dist/**
 .next/**
 coverage/**
+.devbox

--- a/typeid/typeid-js/README.md
+++ b/typeid/typeid-js/README.md
@@ -33,6 +33,8 @@ Using pnpm:
 pnpm add typeid-js
 ```
 
+Note: this package requires Typescript > 5.0.0
+
 # Usage
 
 To create a random TypeID of a given type, use the `typeid()` function:

--- a/typeid/typeid-js/package.json
+++ b/typeid/typeid-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typeid-js",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Official implementation of the TypeID specification in TypeScript. TypeIDs are type-safe, K-sortable, and globally unique identifiers inspired by Stripe IDs",
   "keywords": [
     "typeid",
@@ -35,7 +35,7 @@
     "clean": "rm -rf node_modules && rm -rf dist",
     "dev": "tsup --format esm,cjs --watch --dts",
     "fmt": "pnpm lint --fix",
-    "lint": "prettier --write .",
+    "lint": "prettier '(src|test)/**/*.ts' --write",
     "test": "jest"
   },
   "devDependencies": {

--- a/typeid/typeid-js/src/prefix.ts
+++ b/typeid/typeid-js/src/prefix.ts
@@ -9,8 +9,15 @@ export function isValidPrefix(str: string): boolean {
 
   for (i = 0, len = str.length; i < len; i += 1) {
     code = str.charCodeAt(i);
-    if (!(code > 96 && code < 123)) {
-      // lower alpha (a-z)
+    const isLowerAtoZ = code > 96 && code < 123;
+    const isUnderscore = code === 95;
+
+    // first and last char of prefix can only be [a-z]
+    if ((i === 0 || i === len - 1) && !isLowerAtoZ) {
+      return false;
+    }
+
+    if (!(isLowerAtoZ || isUnderscore)) {
       return false;
     }
   }

--- a/typeid/typeid-js/src/unboxed/typeid.ts
+++ b/typeid/typeid-js/src/unboxed/typeid.ts
@@ -10,7 +10,7 @@ export function typeidUnboxed<T extends string>(
   suffix: string = ""
 ): TypeId<T> {
   if (!isValidPrefix(prefix)) {
-    throw new Error("Invalid prefix. Must be at most 63 ascii letters [a-z]");
+    throw new Error("Invalid prefix. Must be at most 63 ascii letters [a-z_]");
   }
 
   let finalSuffix: string;
@@ -60,27 +60,31 @@ export function fromString<T extends string>(
   typeId: string,
   prefix?: T
 ): TypeId<T> {
-  const parts = typeId.split("_");
+  let p;
+  let s;
 
-  if (parts.length === 1) {
-    return typeidUnboxed("" as T, parts[0]);
-  } else if (parts.length === 2) {
-    if (parts[0] === "") {
+  const underscoreIndex = typeId.lastIndexOf("_");
+  if (underscoreIndex === -1) {
+    p = "" as T;
+    s = typeId;
+  } else {
+    p = typeId.substring(0, underscoreIndex) as T;
+    s = typeId.substring(underscoreIndex + 1);
+
+    if (!p) {
       throw new Error(
         `Invalid TypeId. Prefix cannot be empty when there's a separator: ${typeId}`
       );
     }
-
-    if (prefix && parts[0] !== prefix) {
-      throw new Error(
-        `Invalid TypeId. Prefix mismatch. Expected ${prefix}, got ${parts[0]}`
-      );
-    }
-
-    return typeidUnboxed(parts[0] as T, parts[1]);
-  } else {
-    throw new Error(`Invalid TypeId format: ${typeId}`);
   }
+
+  if (prefix && p !== prefix) {
+    throw new Error(
+      `Invalid TypeId. Prefix mismatch. Expected ${prefix}, got ${p}`
+    );
+  }
+
+  return typeidUnboxed(p, s);
 }
 
 /**
@@ -117,7 +121,7 @@ export function parseTypeId<T extends string>(
  * @returns {T} The prefix of the TypeId.
  */
 export function getType<T extends string>(typeId: TypeId<T>): T {
-  const underscoreIndex = typeId.indexOf("_");
+  const underscoreIndex = typeId.lastIndexOf("_");
   if (underscoreIndex === -1) {
     return "" as T;
   }
@@ -131,7 +135,7 @@ export function getType<T extends string>(typeId: TypeId<T>): T {
  * @returns {string} The suffix of the TypeId.
  */
 export function getSuffix<T extends string>(typeId: TypeId<T>): string {
-  const underscoreIndex = typeId.indexOf("_");
+  const underscoreIndex = typeId.lastIndexOf("_");
   if (underscoreIndex === -1) {
     return typeId;
   }

--- a/typeid/typeid-js/test/invalid.ts
+++ b/typeid/typeid-js/test/invalid.ts
@@ -1,4 +1,14 @@
-// Data copied from the invalid.yml spec file
+/**
+ * This file contains test data that should be treated as *invalid* TypeIDs by
+ * conforming implementations.
+ *
+ * Each example contains an invalid TypeID string. Implementations are expected
+ * to throw an error when attempting to parse/validate these strings.
+ *
+ * Data copied over from the invalid.yml spec file
+ *
+ * Last updated: 2024-04-17 (for version 0.3.0 of the spec)
+ */
 export default [
   {
     name: "prefix-uppercase",
@@ -15,11 +25,12 @@ export default [
     typeid: "pre.fix_00000000000000000000000000",
     description: "The prefix can't have symbols, it needs to be alphabetic",
   },
-  {
-    name: "prefix-underscore",
-    typeid: "pre_fix_00000000000000000000000000",
-    description: "The prefix can't have symbols, it needs to be alphabetic",
-  },
+  // Test removed in v0.3.0 – we now allow underscores in the prefix
+  // {
+  //   name: "prefix-underscore",
+  //   typeid: "pre_fix_00000000000000000000000000",
+  //   description: "The prefix can't have symbols, it needs to be alphabetic",
+  // },
   {
     name: "prefix-non-ascii",
     typeid: "préfix_00000000000000000000000000",
@@ -95,5 +106,16 @@ export default [
     name: "suffix-overflow",
     typeid: "prefix_8zzzzzzzzzzzzzzzzzzzzzzzzz",
     description: "The suffix should encode at most 128-bits",
+  },
+  // Tests below were added in v0.3.0 when we started allowing '_' within the type prefix.
+  {
+    name: "prefix-underscore-start",
+    typeid: "_prefix_00000000000000000000000000",
+    description: "The prefix can't start with an underscore",
+  },
+  {
+    name: "prefix-underscore-end",
+    typeid: "prefix__00000000000000000000000000",
+    description: "The prefix can't end with an underscore",
   },
 ];

--- a/typeid/typeid-js/test/typeid.test.ts
+++ b/typeid/typeid-js/test/typeid.test.ts
@@ -28,11 +28,15 @@ describe("TypeID", () => {
     it("should throw an error if prefix is not lowercase", () => {
       expect(() => {
         typeid("TEST", "00041061050r3gg28a1c60t3gf");
-      }).toThrowError("Invalid prefix. Must be at most 63 ascii letters [a-z]");
+      }).toThrowError(
+        "Invalid prefix. Must be at most 63 ascii letters [a-z_]"
+      );
 
       expect(() => {
         typeid("  ", "00041061050r3gg28a1c60t3gf");
-      }).toThrowError("Invalid prefix. Must be at most 63 ascii letters [a-z]");
+      }).toThrowError(
+        "Invalid prefix. Must be at most 63 ascii letters [a-z_]"
+      );
     });
 
     it("should throw an error if suffix length is not 26", () => {
@@ -95,11 +99,13 @@ describe("TypeID", () => {
     });
 
     it("should throw an error for invalid TypeID string", () => {
-      const invalidStr = "invalid_string_with_underscore";
+      const invalidStr = "invalid_string_with_underscore0000000000000000";
 
       expect(() => {
         TypeID.fromString(invalidStr);
-      }).toThrowError(new Error(`Invalid TypeId format: ${invalidStr}`));
+      }).toThrowError(
+        new Error(`Invalid suffix. First character must be in the range [0-7]`)
+      );
     });
   });
 

--- a/typeid/typeid-js/test/typeid_unboxed.test.ts
+++ b/typeid/typeid-js/test/typeid_unboxed.test.ts
@@ -38,11 +38,15 @@ describe("TypeId Functions", () => {
     it("should throw an error if prefix is not lowercase", () => {
       expect(() => {
         typeidUnboxed("TEST", "00041061050r3gg28a1c60t3gf");
-      }).toThrowError("Invalid prefix. Must be at most 63 ascii letters [a-z]");
+      }).toThrowError(
+        "Invalid prefix. Must be at most 63 ascii letters [a-z_]"
+      );
 
       expect(() => {
         typeidUnboxed("  ", "00041061050r3gg28a1c60t3gf");
-      }).toThrowError("Invalid prefix. Must be at most 63 ascii letters [a-z]");
+      }).toThrowError(
+        "Invalid prefix. Must be at most 63 ascii letters [a-z_]"
+      );
     });
 
     it("should throw an error if suffix length is not 26", () => {
@@ -72,11 +76,13 @@ describe("TypeId Functions", () => {
     });
 
     it("should throw an error for invalid TypeId string", () => {
-      const invalidStr = "invalid_string_with_underscore";
+      const invalidStr = "invalid_string_with_underscore0000000000000000";
 
       expect(() => {
         fromString(invalidStr);
-      }).toThrowError(new Error(`Invalid TypeId format: ${invalidStr}`));
+      }).toThrowError(
+        new Error(`Invalid suffix. First character must be in the range [0-7]`)
+      );
     });
   });
 

--- a/typeid/typeid-js/test/valid.ts
+++ b/typeid/typeid-js/test/valid.ts
@@ -1,4 +1,13 @@
-// Data copied from the valid.yml spec file
+/**
+ * Each example contains:
+ * - The TypeID in its canonical string representation.
+ * - The prefix
+ * - The decoded UUID as a hex string
+ *
+ * Data copied over from the typeid valid.yml spec file
+ *
+ * Last updated: 2024-04-17 (for version 0.3.0 of the spec)
+ */
 export default [
   {
     name: "nil",
@@ -47,5 +56,12 @@ export default [
     typeid: "prefix_01h455vb4pex5vsknk084sn02q",
     prefix: "prefix",
     uuid: "01890a5d-ac96-774b-bcce-b302099a8057",
+  },
+  {
+    // Tests below were added in v0.3.0 when we started allowing '_' within the type prefix.
+    name: "prefix-underscore",
+    typeid: "pre_fix_00000000000000000000000000",
+    prefix: "pre_fix",
+    uuid: "00000000-0000-0000-0000-000000000000",
   },
 ];

--- a/typeid/typeid/README.md
+++ b/typeid/typeid/README.md
@@ -47,7 +47,7 @@ Latest spec version: v0.3.0
 | ----------------------------------------------------- | ------------- | ------------ |
 | [Go](https://github.com/jetify-com/typeid-go)         | ✓ Implemented | v0.3         |
 | [SQL](https://github.com/jetify-com/typeid-sql)       | ✓ Implemented | v0.2         |
-| [TypeScript](https://github.com/jetify-com/typeid-js) | ✓ Implemented | v0.2         |
+| [TypeScript](https://github.com/jetify-com/typeid-js) | ✓ Implemented | v0.3         |
 
 ### Community Provided Implementations
 


### PR DESCRIPTION
## Summary
Add support for spec 0.3 (underscores in type)

## How was it tested?
pnpm build
pnpm test