### PR TITLE
Update spec supported by typeid_elixir package

### DIFF
--- a/typeid/typeid/README.md
+++ b/typeid/typeid/README.md
@@ -57,7 +57,7 @@ Latest spec version: v0.3.0
 | [C# (.Net Standard 2.1)](https://github.com/cbuctok/typeId)   | [@cbuctok](https://github.com/cbuctok)                                                    | v0.2 on 2023-07-03 |
 | [C# (.NET)](https://github.com/firenero/TypeId)               | [@firenero](https://github.com/firenero)                                                  | v0.3 on 2024-04-15 |
 | [Dart](https://github.com/TBD54566975/typeid-dart)            | [@mistermoe](https://github.com/mistermoe) [@tbd54566975](https://github.com/tbd54566975) | v0.2 on 2024-03-25 |
-| [Elixir](https://github.com/sloanelybutsurely/typeid-elixir)  | [@sloanelybutsurely](https://github.com/sloanelybutsurely)                                | v0.2 on 2023-07-02 |
+| [Elixir](https://github.com/sloanelybutsurely/typeid-elixir)  | [@sloanelybutsurely](https://github.com/sloanelybutsurely)                                | v0.3 on 2024-04-22 |
 | [Haskell](https://github.com/MMZK1526/mmzk-typeid)            | [@MMZK1526](https://github.com/MMZK1526)                                                  | v0.2 on 2023-07-07 |
 | [Java](https://github.com/fxlae/typeid-java)                  | [@fxlae](https://github.com/fxlae)                                                        | v0.3 on 2024-04-14 |
 | [Java](https://github.com/softprops/typeid-java)              | [@softprops](https://github.com/softprops)                                                | v0.2 on 2023-07-04 |


### PR DESCRIPTION
## Summary

- https://github.com/sloanelybutsurely/typeid-elixir/pull/30
- published as [0.6.0](https://github.com/sloanelybutsurely/typeid-elixir/releases/tag/0.6.0) ([hex.pm](https://diff.hex.pm/diff/typeid_elixir/0.5.3..0.6.0))

## How was it tested?

- spec yaml files [were updated](https://github.com/sloanelybutsurely/typeid-elixir/pull/30/files?file-filters%5B%5D=.yml&show-deleted-files=true&show-viewed-files=true) and generated tests re-run
