### PR TITLE
Update strong_id's target spec version

### DIFF
--- a/typeid/typeid/README.md
+++ b/typeid/typeid/README.md
@@ -65,8 +65,8 @@ Latest spec version: v0.3.0
 | [PHP](https://github.com/BombenProdukt/typeid)                | [@BombenProdukt](https://github.com/BombenProdukt)                                        | v0.2 on 2023-07-03 |
 | [Python](https://github.com/akhundMurad/typeid-python)        | [@akhundMurad](https://github.com/akhundMurad)                                            | v0.2 on 2023-06-30 |
 | [Ruby](https://github.com/broothie/typeid-ruby)               | [@broothie](https://github.com/broothie)                                                  | [v0.3 on 2024-04-13](https://github.com/broothie/typeid-ruby/pull/17) |
-| [Rust](https://github.com/conradludgate/type-safe-id)         | [@conradludgate](https://github.com/conradludgate)                                        | [v0.3 on 2023-04-12](https://github.com/conradludgate/type-safe-id/pull/1) |
-| [Rust](https://github.com/johnnynotsolucky/strong_id)         | [@johnnynotsolucky](https://github.com/johnnynotsolucky)                                  | v0.2 on 2023-07-13 |
+| [Rust](https://github.com/conradludgate/type-safe-id)         | [@conradludgate](https://github.com/conradludgate)                                        | [v0.3 on 2024-04-12](https://github.com/conradludgate/type-safe-id/pull/1) |
+| [Rust](https://github.com/johnnynotsolucky/strong_id)         | [@johnnynotsolucky](https://github.com/johnnynotsolucky)                                  | [v0.3 on 2024-05-17](https://github.com/johnnynotsolucky/strong_id/commit/10aa50487bbdd851c58a2ed73071a50452441370) |
 | [Scala](https://github.com/ant8e/uuid4cats-effect)            | [@ant8e](https://github.com/ant8e)                                                        | v0.3 on 2024-04-19 |
 | [Scala](https://github.com/guizmaii-opensource/zio-uuid)      | [@guizmaii](https://github.com/guizmaii)                                                  | Not validated yet  |
 | [Swift](https://github.com/Frizlab/swift-typeid)              | [@Frizlab](https://github.com/Frizlab)                                                    | v0.3 on 2024-04-19 |


### PR DESCRIPTION
## Summary

- This PR updates the spec version that `strong_id` 0.4 targets.
- It also corrects the year in @conradludgate's `type-safe-id` package.

## How was it tested?

The Typeid Spec workflow has been updated and is now passing: https://github.com/johnnynotsolucky/strong_id/actions/runs/9133864191