### PR TITLE
Fix `suffix-hyphens` description in test data invalid.yml

### DIFF
--- a/typeid/typeid-go/testdata/invalid.yml
+++ b/typeid/typeid-go/testdata/invalid.yml
@@ -4,7 +4,7 @@
 # Each example contains an invalid TypeID string. Implementations are expected
 # to throw an error when attempting to parse/validate these strings.
 #
-# Last updated: 2024-04-10 (for version 0.3.0 of the spec)
+# Last updated: 2024-05-18 (for version 0.3.0 of the spec)
 
 - name: prefix-uppercase
   typeid: "PREFIX_00000000000000000000000000"
@@ -67,7 +67,7 @@
   # This example has the right length, so that the failure is caused by the hyphens
   # and not the suffix length
   typeid: "prefix_123456789-123456789-123456"
-  description: "The suffix should be lowercase with no uppercase letters"
+  description: "The suffix can't have any hyphens"
 
 - name: suffix-wrong-alphabet
   typeid: "prefix_ooooooiiiiiiuuuuuuulllllll"

--- a/typeid/typeid/spec/invalid.json
+++ b/typeid/typeid/spec/invalid.json
@@ -62,7 +62,7 @@
   {
     "name": "suffix-hyphens",
     "typeid": "prefix_123456789-123456789-123456",
-    "description": "The suffix should be lowercase with no uppercase letters"
+    "description": "The suffix can't have any hyphens"
   },
   {
     "name": "suffix-wrong-alphabet",

--- a/typeid/typeid/spec/invalid.yml
+++ b/typeid/typeid/spec/invalid.yml
@@ -4,7 +4,7 @@
 # Each example contains an invalid TypeID string. Implementations are expected
 # to throw an error when attempting to parse/validate these strings.
 #
-# Last updated: 2024-04-10 (for version 0.3.0 of the spec)
+# Last updated: 2024-05-18 (for version 0.3.0 of the spec)
 
 - name: prefix-uppercase
   typeid: "PREFIX_00000000000000000000000000"
@@ -67,7 +67,7 @@
   # This example has the right length, so that the failure is caused by the hyphens
   # and not the suffix length
   typeid: "prefix_123456789-123456789-123456"
-  description: "The suffix should be lowercase with no uppercase letters"
+  description: "The suffix can't have any hyphens"
 
 - name: suffix-wrong-alphabet
   typeid: "prefix_ooooooiiiiiiuuuuuuulllllll"


### PR DESCRIPTION
## Summary

Changes description of the test to match its meaning.

## How was it tested?

Run `pnpm test` and `go test`.

