### PR TITLE
[typeid-js] Enforce prefix (optionally)

### DIFF
--- a/typeid/typeid-js/README.md
+++ b/typeid/typeid-js/README.md
@@ -75,11 +75,9 @@ For example, to parse an existing typeid from a string:
 ```typescript
 import { TypeID } from 'typeid-js';
 
-// The asType() call is optional, but it converts to type TypeID<"prefix"> instead
-// of TypeID<string>
-const tid = TypeID.fromString('prefix_00041061050r3gg28a1c60t3gf').asType(
-    'prefix'
-);
+// The prefix is optional, but it enforces the prefix and returns a
+// TypeID<"prefix"> instead of TypeID<string>
+const tid = TypeID.fromString('prefix_00041061050r3gg28a1c60t3gf', 'prefix');
 ```
 
 To encode an existing UUID as a TypeID:
@@ -98,6 +96,6 @@ The full list of methods includes:
 -   `toString()`: Encodes the object as a string, using the canonical format
 -   `toUUID()`: Decodes the TypeID into a UUID string in hex format. The type prefix is ignored
 -   `toUUIDBytes()`: Decodes the TypeID into a UUID byte array. The type prefix is ignored
--   `fromString(str)`: Parses a TypeID from a string
+-   `fromString(str, prefix?)`: Parses a TypeID from a string, optionally checking the prefix
 -   `fromUUID(prefix, uuid)`: Creates a TypeID from a prefix and a UUID in hex format
 -   `fromUUIDBytes(prefix, bytes)`: Creates a TypeID from a prefix and a UUID in byte array format

--- a/typeid/typeid-js/package.json
+++ b/typeid/typeid-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typeid-js",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Official implementation of the TypeID specification in TypeScript. TypeIDs are type-safe, K-sortable, and globally unique identifiers inspired by Stripe IDs",
   "keywords": [
     "typeid",

--- a/typeid/typeid-js/src/typeid.ts
+++ b/typeid/typeid-js/src/typeid.ts
@@ -50,8 +50,8 @@ export class TypeID<const T extends string> {
     return `${this.prefix}_${this.suffix}`;
   }
 
-  static fromString<const T extends string>(str: string): TypeID<T> {
-    const typeIdRaw = fromString(str);
+  static fromString<const T extends string>(str: string, prefix?: T): TypeID<T> {
+    const typeIdRaw = fromString(str, prefix);
 
     return new TypeID<T>(getType(typeIdRaw) as T, getSuffix(typeIdRaw));
   }

--- a/typeid/typeid-js/test/typeid.test.ts
+++ b/typeid/typeid-js/test/typeid.test.ts
@@ -98,6 +98,14 @@ describe("TypeID", () => {
       expect(tid.getType()).toBe("prefix");
     });
 
+    it("should construct TypeID from a string with prefix and specified prefix", () => {
+      const str = "prefix_00041061050r3gg28a1c60t3gf";
+      const tid = TypeID.fromString(str);
+
+      expect(tid.getSuffix()).toBe("00041061050r3gg28a1c60t3gf");
+      expect(tid.getType()).toBe("prefix");
+    });
+
     it("should throw an error for invalid TypeID string", () => {
       const invalidStr = "invalid_string_with_underscore0000000000000000";
 
@@ -105,6 +113,14 @@ describe("TypeID", () => {
         TypeID.fromString(invalidStr);
       }).toThrowError(
         new Error(`Invalid suffix. First character must be in the range [0-7]`)
+      );
+    });
+    it("should throw an error with wrong prefix", () => {
+      const str = "prefix_00041061050r3gg28a1c60t3gf";
+      expect(() => {
+        TypeID.fromString(str, "wrong");
+      }).toThrowError(
+        new Error(`Invalid TypeId. Prefix mismatch. Expected wrong, got prefix`)
       );
     });
   });
@@ -203,3 +219,4 @@ describe("TypeID", () => {
     });
   });
 });
+

--- a/typeid/typeid-js/test/typeid.test.ts
+++ b/typeid/typeid-js/test/typeid.test.ts
@@ -100,7 +100,7 @@ describe("TypeID", () => {
 
     it("should construct TypeID from a string with prefix and specified prefix", () => {
       const str = "prefix_00041061050r3gg28a1c60t3gf";
-      const tid = TypeID.fromString(str);
+      const tid = TypeID.fromString(str, "prefix");
 
       expect(tid.getSuffix()).toBe("00041061050r3gg28a1c60t3gf");
       expect(tid.getType()).toBe("prefix");
@@ -219,4 +219,3 @@ describe("TypeID", () => {
     });
   });
 });
-


### PR DESCRIPTION
## Summary

Brings it inline with unboxed version. Makes type-checking much more reliable (because it now throws an error if prefix is wrong). Because the current implementation uses `as T`, if the prefix is not specified, the typechecker type has no relationship to the input data.

Arguably this should have been the default. It requires the same amount of typing because the template type doesn't need to be added:

```ts
const id = TypeID.fromString(stringId, "foo")
// id is of type TypeID<"foo">
```

Unfortunately we can't do this without breaking backward compatibility. 

## How was it tested?

unit tests