### PR TITLE
[typeid-js] Throw error when parsing typeid with empty suffix

### DIFF
--- a/typeid/typeid-js/src/typeid.ts
+++ b/typeid/typeid-js/src/typeid.ts
@@ -50,7 +50,10 @@ export class TypeID<const T extends string> {
     return `${this.prefix}_${this.suffix}`;
   }
 
-  static fromString<const T extends string>(str: string, prefix?: T): TypeID<T> {
+  static fromString<const T extends string>(
+    str: string,
+    prefix?: T
+  ): TypeID<T> {
     const typeIdRaw = fromString(str, prefix);
 
     return new TypeID<T>(getType(typeIdRaw) as T, getSuffix(typeIdRaw));

--- a/typeid/typeid-js/src/unboxed/typeid.ts
+++ b/typeid/typeid-js/src/unboxed/typeid.ts
@@ -78,6 +78,10 @@ export function fromString<T extends string>(
     }
   }
 
+  if (!s) {
+    throw new Error(`Invalid TypeId. Suffix cannot be empty`);
+  }
+
   if (prefix && p !== prefix) {
     throw new Error(
       `Invalid TypeId. Prefix mismatch. Expected ${prefix}, got ${p}`

--- a/typeid/typeid-js/test/typeid.test.ts
+++ b/typeid/typeid-js/test/typeid.test.ts
@@ -123,6 +123,18 @@ describe("TypeID", () => {
         new Error(`Invalid TypeId. Prefix mismatch. Expected wrong, got prefix`)
       );
     });
+    it("should throw an error for empty TypeId string", () => {
+      const invalidStr = "";
+      expect(() => {
+        TypeID.fromString(invalidStr);
+      }).toThrowError(new Error(`Invalid TypeId. Suffix cannot be empty`));
+    });
+    it("should throw an error for TypeId string with empty suffix", () => {
+      const invalidStr = "prefix_";
+      expect(() => {
+        TypeID.fromString(invalidStr);
+      }).toThrowError(new Error(`Invalid TypeId. Suffix cannot be empty`));
+    });
   });
 
   describe("fromUUIDBytes", () => {

--- a/typeid/typeid-js/test/typeid_unboxed.test.ts
+++ b/typeid/typeid-js/test/typeid_unboxed.test.ts
@@ -84,6 +84,22 @@ describe("TypeId Functions", () => {
         new Error(`Invalid suffix. First character must be in the range [0-7]`)
       );
     });
+
+    it("should throw an error for empty TypeId string", () => {
+      const invalidStr = "";
+
+      expect(() => {
+        fromString(invalidStr);
+      }).toThrowError(new Error(`Invalid TypeId. Suffix cannot be empty`));
+    });
+
+    it("should throw an error for TypeId string with empty suffix", () => {
+      const invalidStr = "prefix_";
+
+      expect(() => {
+        fromString(invalidStr);
+      }).toThrowError(new Error(`Invalid TypeId. Suffix cannot be empty`));
+    });
   });
 
   describe("fromUUIDBytes", () => {


### PR DESCRIPTION
## Summary
Throw an error when parsing typeid with empty suffix

Addresses https://github.com/jetify-com/typeid-js/issues/12

## How was it tested?
pnpm test