### PR TITLE
Generalize publish code action so it can publish to different orgs

### DIFF
--- a/.github/workflows/publish-repos.yml
+++ b/.github/workflows/publish-repos.yml
@@ -12,6 +12,7 @@ on:
   push:
     branches:
       - main # When we merge to main
+      - rodrigo/*
     tags:
       - "**" # If we added a tag (used for releases)
 
@@ -44,8 +45,8 @@ jobs:
           # if you relocate a subdirectory within the monorepo, you need to update this
           # yaml for things to continue to work.
           targets: >
-            envsec
-            nixtest
+            envsec:envsec2
+            nixtest:anotherorg/nixtest
             pkg
             typeid/typeid
             typeid/typeid-go

--- a/.github/workflows/publish-repos.yml
+++ b/.github/workflows/publish-repos.yml
@@ -45,7 +45,7 @@ jobs:
           # if you relocate a subdirectory within the monorepo, you need to update this
           # yaml for things to continue to work.
           targets: >
-            action-publish-code:test-repo
+            action-publish-code:jetify-examples/test-repo
 #            envsec:envsec2
 #            nixtest:anotherorg/nixtest
 #            pkg

--- a/.github/workflows/publish-repos.yml
+++ b/.github/workflows/publish-repos.yml
@@ -12,7 +12,6 @@ on:
   push:
     branches:
       - main # When we merge to main
-      - rodrigo/*
     tags:
       - "**" # If we added a tag (used for releases)
 
@@ -45,15 +44,14 @@ jobs:
           # if you relocate a subdirectory within the monorepo, you need to update this
           # yaml for things to continue to work.
           targets: >
-            action-publish-code:jetify-examples/test-repo
-#            envsec:envsec2
-#            nixtest:anotherorg/nixtest
-#            pkg
-#            typeid/typeid
-#            typeid/typeid-go
-#            typeid/typeid-sql
-#            typeid/typeid-js
-#            tyson
+            envsec:envsec2
+            nixtest:anotherorg/nixtest
+            pkg
+            typeid/typeid
+            typeid/typeid-go
+            typeid/typeid-sql
+            typeid/typeid-js
+            tyson
 
   create-dependency-update-pr:
     needs: publish-repos

--- a/.github/workflows/publish-repos.yml
+++ b/.github/workflows/publish-repos.yml
@@ -44,8 +44,8 @@ jobs:
           # if you relocate a subdirectory within the monorepo, you need to update this
           # yaml for things to continue to work.
           targets: >
-            envsec:envsec2
-            nixtest:anotherorg/nixtest
+            envsec
+            nixtest
             pkg
             typeid/typeid
             typeid/typeid-go

--- a/.github/workflows/publish-repos.yml
+++ b/.github/workflows/publish-repos.yml
@@ -45,14 +45,15 @@ jobs:
           # if you relocate a subdirectory within the monorepo, you need to update this
           # yaml for things to continue to work.
           targets: >
-            envsec:envsec2
-            nixtest:anotherorg/nixtest
-            pkg
-            typeid/typeid
-            typeid/typeid-go
-            typeid/typeid-sql
-            typeid/typeid-js
-            tyson
+            test:test-repo
+#            envsec:envsec2
+#            nixtest:anotherorg/nixtest
+#            pkg
+#            typeid/typeid
+#            typeid/typeid-go
+#            typeid/typeid-sql
+#            typeid/typeid-js
+#            tyson
 
   create-dependency-update-pr:
     needs: publish-repos

--- a/.github/workflows/publish-repos.yml
+++ b/.github/workflows/publish-repos.yml
@@ -45,7 +45,7 @@ jobs:
           # if you relocate a subdirectory within the monorepo, you need to update this
           # yaml for things to continue to work.
           targets: >
-            test:test-repo
+            action-publish-code:test-repo
 #            envsec:envsec2
 #            nixtest:anotherorg/nixtest
 #            pkg

--- a/action-publish-code/action.yml
+++ b/action-publish-code/action.yml
@@ -2,7 +2,7 @@ name: "Publish Code"
 description: |
   A Github action that makes it easy to publish code from one git repository to another
   while preserving history. The primary use case is to mirror code from a directory
-  in a monorepo, and publish it as a standalone repository."
+  in a monorepo, and publish it as a standalone repository.
 author: "jetify"
 inputs:
   origin:

--- a/action-publish-code/publish-code.sh
+++ b/action-publish-code/publish-code.sh
@@ -24,26 +24,27 @@ origin_repo="${1##*/}"
 shift
 
 function parse_target() {
-  # Valid target examples: dir1/dir2, dir2:repo2, dir3:org2/repo3
-  if [[ "$1" =~ ^([^:]+)(:([^/]+/)?([^/]+))?$ ]]; then
-    dir="${BASH_REMATCH[1]}"
-    target_org="${BASH_REMATCH[3]}"
-    target_repo="${BASH_REMATCH[4]}"
+	# Valid target examples: dir1/dir2, dir2:repo2, dir3:org2/repo3
 
-    if [ -z "$target_repo" ]; then
-      target_repo=$(basename "$dir")
-    fi
+	if [[ "$1" =~ ^([^:]+)(:([^/]+/)?([^/]+))?$ ]]; then
+		dir="${BASH_REMATCH[1]}"
+		target_org="${BASH_REMATCH[3]}"
+		target_repo="${BASH_REMATCH[4]}"
 
-    target_org="${target_org%/}"  # remove trailing slash if present
-    if [ -z "$target_org" ]; then
-      target_org="$org"
-    fi
+		if [ -z "$target_repo" ]; then
+			target_repo=$(basename "$dir")
+		fi
 
-    echo "$dir $target_org $target_repo"
-  else
-    echo "error: invalid target argument: $1"
-    exit 1
-  fi
+		target_org="${target_org%/}"	# remove trailing slash if present
+		if [ -z "$target_org" ]; then
+			target_org="$org"
+		fi
+
+		echo "$dir $target_org $target_repo"
+	else
+		echo "error: invalid target argument: $1"
+		exit 1
+	fi
 }
 
 # Create a temporary directory into which to clone the repos:
@@ -63,7 +64,7 @@ echo -e "\n"
 cd "${TMPDIR}/${origin_repo}"
 for arg in "$@"; do
 	echo "Validating $arg"
-  read -r dir target_org target_repo <<< "$(parse_target "$arg")"
+	read -r dir target_org target_repo <<< "$(parse_target "$arg")"
 
 	# Just to be extra safe, make sure we're not trying to publish to origin repo itself
 	if [ "${target_org}/${target_repo}" = "${org}/${origin_repo}" ]; then
@@ -79,7 +80,7 @@ for arg in "$@"; do
 done
 
 for arg in "$@"; do
-  read -r dir target_org target_repo <<< "$(parse_target "$arg")"
+	read -r dir target_org target_repo <<< "$(parse_target "$arg")"
 
 	echo "Publishing dir '${dir}' to repo '${target_org}/${target_repo}' ..."
 
@@ -121,7 +122,7 @@ for arg in "$@"; do
 	# Undo the filtering so we can re-use the source repo for another rewrite.
 	git for-each-ref --format="update %(refname:lstrip=2) %(objectname)" refs/original/ | git update-ref --stdin
 	git for-each-ref --format="delete %(refname) %(objectname)" refs/original/ | git update-ref --stdin
-	git fetch --tags --force  # Restore all tags
+	git fetch --tags --force	# Restore all tags
 	git reset --hard HEAD
 
 	echo "[DONE] Published dir '${dir}' to repo '${target_org}/${target_repo}' ..."

--- a/action-publish-code/publish-code.sh
+++ b/action-publish-code/publish-code.sh
@@ -26,16 +26,15 @@ shift
 function parse_target() {
   # Valid target examples: dir1, dir2:repo2, dir3:org2/repo3
   if [[ "$1" =~ ^([^:]+)(:([^/]+/)?([^/]+))?$ ]]; then
-    dir="${BASH_REMATCH[1]}"      # Captures <dir>
-    target_org="${BASH_REMATCH[3]}"    # Captures <owner>/ (with trailing / if present)
-    target_repo="${BASH_REMATCH[4]}"     # Captures <name>
+    dir="${BASH_REMATCH[1]}"
+    target_org="${BASH_REMATCH[3]}"
+    target_repo="${BASH_REMATCH[4]}"
 
     if [ -z "$target_repo" ]; then
       target_repo="$dir"
     fi
 
-    # Remove trailing slash from owner if it's present
-    target_org="${target_org%/}"
+    target_org="${target_org%/}"  # remove trailing slash if present
     if [ -z "$target_org" ]; then
       target_org="$org"
     fi
@@ -43,6 +42,7 @@ function parse_target() {
     echo "$dir $target_org $target_repo"
   else
     echo "error: invalid target argument: $1"
+    exit 1
   fi
 }
 

--- a/action-publish-code/publish-code.sh
+++ b/action-publish-code/publish-code.sh
@@ -59,12 +59,23 @@ for arg in "$@"; do
 done
 
 for arg in "$@"; do
+  if [[ "$arg" =~ ^([^:]+)(:([^/]+/)?([^/]+))?$ ]]; then
+    dir="${BASH_REMATCH[1]}"      # Captures <dir>
+    target_org="${BASH_REMATCH[3]}"    # Captures <owner>/ (with trailing / if present)
+    target_repo="${BASH_REMATCH[4]}"     # Captures <name>
+
+    # Remove trailing slash from owner if it's present
+    target_org="${target_org%/}"
+  fi
+
 	dir="${arg%:*}"
 	repo="${dir##*/}"
 	if [[ "$arg" = *":"* ]]; then
 		repo="${arg##*:}"
 	fi
 	echo "Publishing dir '${dir}' to repo '${repo}' ..."
+	echo "Publishing dir '${dir}' to repo '${target_org}/${target_repo}' ..."
+	continue
 
 	set -o xtrace # Print commands as they are executed
 

--- a/action-publish-code/publish-code.sh
+++ b/action-publish-code/publish-code.sh
@@ -35,7 +35,7 @@ function parse_target() {
 			target_repo=$(basename "$dir")
 		fi
 
-		target_org="${target_org%/}"	# remove trailing slash if present
+		target_org="${target_org%/}" # remove trailing slash if present
 		if [ -z "$target_org" ]; then
 			target_org="$org"
 		fi
@@ -122,7 +122,7 @@ for arg in "$@"; do
 	# Undo the filtering so we can re-use the source repo for another rewrite.
 	git for-each-ref --format="update %(refname:lstrip=2) %(objectname)" refs/original/ | git update-ref --stdin
 	git for-each-ref --format="delete %(refname) %(objectname)" refs/original/ | git update-ref --stdin
-	git fetch --tags --force	# Restore all tags
+	git fetch --tags --force # Restore all tags
 	git reset --hard HEAD
 
 	echo "[DONE] Published dir '${dir}' to repo '${target_org}/${target_repo}' ..."

--- a/action-publish-code/publish-code.sh
+++ b/action-publish-code/publish-code.sh
@@ -65,6 +65,7 @@ for arg in "$@"; do
 		repo="${arg##*:}"
 	fi
 	echo "Publishing dir '${dir}' to repo '${repo}' ..."
+	continue
 
 	set -o xtrace # Print commands as they are executed
 

--- a/action-publish-code/publish-code.sh
+++ b/action-publish-code/publish-code.sh
@@ -65,7 +65,6 @@ for arg in "$@"; do
 		repo="${arg##*:}"
 	fi
 	echo "Publishing dir '${dir}' to repo '${repo}' ..."
-	continue
 
 	set -o xtrace # Print commands as they are executed
 
@@ -79,7 +78,7 @@ for arg in "$@"; do
 		--tag-name-filter "grep '^${repo}/' | cut -f 2- -d '/'" \
 		--subdirectory-filter "${dir}" --prune-empty -- --all
 
-	git clone "git@github.com:${org}/${repo}.git" "${TMPDIR}/${repo}"
+	git clone "git@github.com:jetify-examples/${repo}.git" "${TMPDIR}/${repo}"
 	pushd "${TMPDIR}/${repo}"
 
 	# Here is the trick. Connect your source repository as a remote using a local reference.

--- a/action-publish-code/publish-code.sh
+++ b/action-publish-code/publish-code.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
 
-# Publishes a subdirectory in a given git repository as a standalone repository of it's own.
+# Publishes a subdirectory in a given git repository as a standalone repository of its own.
 
 set -euo pipefail
 set -o errexit
 set -o nounset
 
 if [ "$#" = 0 ]; then
-	echo "usage: $0 <org>/<repo> <dir1>[:<repo1>] [<dirN>[:<repoN>]]..." 1>&2
+	echo "usage: $0 <org>/<repo> <dir1>[:[<owner1>/]<repo1>] [<dirN>[:[<ownerN/]<repoN>]]..." 1>&2
 	exit 1
 fi
 
 if [[ "$1" != *"/"* ]]; then
-	echo "error: first argument must be in the form <owner>/<repo>" 1>&2
+	echo "error: first argument must be in the form <owner>/<repo>, where <repo> is [<org>/]<repo-name>" 1>&2
 	echo "usage: $0 <org>/<repo> <dir1>[:[<owner1>/]<repo1>] [<dirN>[:[<ownerN/]<repoN>]]..." 1>&2
 	echo "example: $0 org1/repo1 dir1 dir2:repo2 dir3:org2/repo3" 1>&2
 	exit 1
@@ -24,14 +24,14 @@ origin_repo="${1##*/}"
 shift
 
 function parse_target() {
-  # Valid target examples: dir1, dir2:repo2, dir3:org2/repo3
+  # Valid target examples: dir1/dir2, dir2:repo2, dir3:org2/repo3
   if [[ "$1" =~ ^([^:]+)(:([^/]+/)?([^/]+))?$ ]]; then
     dir="${BASH_REMATCH[1]}"
     target_org="${BASH_REMATCH[3]}"
     target_repo="${BASH_REMATCH[4]}"
 
     if [ -z "$target_repo" ]; then
-      target_repo="$dir"
+      target_repo=$(basename "$dir")
     fi
 
     target_org="${target_org%/}"  # remove trailing slash if present
@@ -45,14 +45,6 @@ function parse_target() {
     exit 1
   fi
 }
-
-#for arg in "$@"; do
-#  read -r dir target_org target_repo <<< "$(parse_target "$arg")"
-#	echo "Publishing ${org}/${origin_repo}'s dir '${dir}' to repo '${target_org}/${target_repo}' ..."
-#	continue
-#done
-#
-#exit 0
 
 # Create a temporary directory into which to clone the repos:
 TMPDIR=$(mktemp -d)


### PR DESCRIPTION
## Summary
Assuming the source repo is `org1/repo1`, the targets can now be of these forms:
* `dir1/dir2` -> publishes to `org1/dir2`
* `dir2:repo2` -> publishes to `org1/repo2`
* `dir3:org2/repo3` -> publishes to `org2/repo3`

## How was it tested?
Ran locally (without actually publishing anything).

Also tested publishing to `jetify-examples/test-repo`:
https://github.com/jetify-com/opensource/actions/runs/10375981931/job/28726924974