### PR TITLE
[runx] Add support for fetching private GitHub release assets

### DIFF
--- a/pkg/runx/impl/github/convert.go
+++ b/pkg/runx/impl/github/convert.go
@@ -34,13 +34,14 @@ func convertGithubAssets(assets []*githubimpl.ReleaseAsset) []types.ArtifactMeta
 			continue
 		}
 		result = append(result, types.ArtifactMetadata{
-			DownloadURL:   asset.GetBrowserDownloadURL(),
-			Name:          asset.GetName(),
-			DownloadCount: asset.GetDownloadCount(),
-			CreatedAt:     asset.GetCreatedAt().Time,
-			UpdatedAt:     asset.GetUpdatedAt().Time,
-			ContentType:   asset.GetContentType(),
-			Size:          asset.GetSize(),
+			URL:                asset.GetURL(),
+			BrowserDownloadURL: asset.GetBrowserDownloadURL(),
+			Name:               asset.GetName(),
+			DownloadCount:      asset.GetDownloadCount(),
+			CreatedAt:          asset.GetCreatedAt().Time,
+			UpdatedAt:          asset.GetUpdatedAt().Time,
+			ContentType:        asset.GetContentType(),
+			Size:               asset.GetSize(),
 		})
 	}
 	return result

--- a/pkg/runx/impl/registry/registry.go
+++ b/pkg/runx/impl/registry/registry.go
@@ -17,6 +17,7 @@ var xdgInstallationSubdir = "runx/pkgs"
 type Registry struct {
 	rootPath fileutil.Path
 	gh       *github.Client
+	download *download.Client
 }
 
 func NewLocalRegistry(ctx context.Context, githubAPIToken string) (*Registry, error) {
@@ -35,6 +36,7 @@ func NewLocalRegistry(ctx context.Context, githubAPIToken string) (*Registry, er
 	return &Registry{
 		rootPath: rootPath,
 		gh:       github.NewClient(ctx, githubAPIToken),
+		download: download.NewClient(githubAPIToken),
 	}, nil
 }
 
@@ -89,7 +91,7 @@ func (r *Registry) GetArtifact(ctx context.Context, ref types.PkgRef, platform t
 	}
 
 	path := r.rootPath.Subpath(resolvedRef.Owner, resolvedRef.Repo, resolvedRef.Version, metadata.Name)
-	err = download.DownloadOnce(metadata.DownloadURL, path.String())
+	err = r.download.DownloadOnce(metadata.URL, path.String())
 	if err != nil {
 		return "", err
 	}

--- a/pkg/runx/impl/types/types.go
+++ b/pkg/runx/impl/types/types.go
@@ -21,7 +21,8 @@ type ArtifactMetadata struct {
 	// github api. But if we want to get releases from other sources, or allow publishes to embed
 	// this metadata with their releases, some of these won't apply (i.e. DownloadCount).
 
-	DownloadURL string `json:"download_url"`
+	URL                string `json:"url"`
+	BrowserDownloadURL string `json:"browser_download_url"`
 
 	Name          string    `json:"name"`
 	DownloadCount int       `json:"download_count"`


### PR DESCRIPTION
## Summary

Allows runx to download release assets from private repositories, fixes https://github.com/jetify-com/devbox/issues/2223

- Adds a constructor for `download` to set the GitHub token 
- Switches to use the api url instead of browser url when downloading assets
- Sets `Accept` header to `application/octet-stream` to get the binary instead of json metadata for the asset

## How was it tested?

I have tested the `runx` cli locally with and without `RUNX_GITHUB_API_TOKEN` set. With the environment variable the release asset is downloaded correctly from private repositories. Without the environment variable public repositories works fine and private returns `404`.

I also build `devbox` locally and tested with and without `DEVBOX_GITHUB_API_TOKEN` set and it works the same as running the `runx` cli directly.