### PR TITLE
[templates] Publish templates from opensource repo

### DIFF
--- a/.github/workflows/publish-repos.yml
+++ b/.github/workflows/publish-repos.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         project_id: [dev-j3tpk, nonprod-j3tpk, prod-j3tpk]
-        template: [hello-go]
+        template: [deno-fresh, elixir-phoenix, go-gin, php-laravel, python-flask, typescript-remix]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
I'm not 100% sure if this will work the first time, but let's try it. The reason why it might not work is because it'll try to merge whatever is in this repo (in each template) onto the corresponding template repo. It should result in an empty diff and therefore succeed, but again I'm not 100% sure if there's some other check (e.g. history) that might make it fail.

## How was it tested?
After merging I'll fix-forward if needed.