### PR TITLE
[templates] Only publish templates that use devbox

### DIFF
--- a/.github/workflows/publish-repos.yml
+++ b/.github/workflows/publish-repos.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         project_id: [dev-j3tpk, nonprod-j3tpk, prod-j3tpk]
-        template: [deno-fresh, elixir-phoenix, go-gin, php-laravel, python-flask, typescript-remix]
+        template: [deno-fresh, elixir-phoenix, php-laravel, python-flask]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
The publishing only supports building from devbox or from docker, not nix or buildpacks, so I removed those. I'll add devbox to them afterwards.

## How was it tested?
CICD