### PR TITLE
[runx] Allow unknown file types

### DIFF
--- a/pkg/runx/devbox.json
+++ b/pkg/runx/devbox.json
@@ -5,7 +5,8 @@
   "shell": {
     "scripts": {
       "build": "go build -o dist/runx cmd/runx/main.go",
-      "build-pkg": "go build -o dist/pkg cmd/pkg/main.go"
+      "build-pkg": "go build -o dist/pkg cmd/pkg/main.go",
+      "test": "go test ./..."
     }
   }
 }

--- a/pkg/runx/impl/registry/registry_test.go
+++ b/pkg/runx/impl/registry/registry_test.go
@@ -98,8 +98,8 @@ func TestFindArtifactForPlatform(t *testing.T) {
 		errTypeWant error
 	}{
 		{[]types.ArtifactMetadata{{Name: "mac-amd64.tar.gz"}}, types.NewPlatform("darwin", "amd64"), true, nil},
-		{[]types.ArtifactMetadata{{Name: "linux-amd64.deb"}}, types.NewPlatform("linux", "amd64"), false, types.ErrNoKnownArchive},
-		{[]types.ArtifactMetadata{{Name: "linux-amd64"}}, types.NewPlatform("linux", "amd64"), false, types.ErrNoKnownArchive},
+		{[]types.ArtifactMetadata{{Name: "linux-amd64.deb"}}, types.NewPlatform("linux", "amd64"), true, nil},
+		{[]types.ArtifactMetadata{{Name: "linux-amd64"}}, types.NewPlatform("linux", "amd64"), true, nil},
 		{[]types.ArtifactMetadata{{Name: "darwin_arm64.tar"}}, types.NewPlatform("windows", "amd64"), false, types.ErrPlatformNotSupported},
 		{[]types.ArtifactMetadata{{Name: "darwin_arm64"}}, types.NewPlatform("windows", "amd64"), false, types.ErrPlatformNotSupported},
 		{[]types.ArtifactMetadata{{Name: "mac-amd64.tar.gz"}}, types.NewPlatform("", ""), false, types.ErrPlatformNotSupported},

--- a/pkg/runx/impl/types/errors.go
+++ b/pkg/runx/impl/types/errors.go
@@ -5,4 +5,3 @@ import "errors"
 var ErrPackageNotFound = errors.New("package not found")
 var ErrReleaseNotFound = errors.New("release not found")
 var ErrPlatformNotSupported = errors.New("package doesn't support platform")
-var ErrNoKnownArchive = errors.New("package doesn't come in a known archive")


### PR DESCRIPTION
## Summary

This tweaks the logic in https://github.com/jetify-com/opensource/pull/401 to allow unknown file types if there are no known file types in the list of released artifacts. This is needed because some releases don't have file types at all (e.g. https://github.com/mvdan/gofumpt/releases). We try to return a known archive, otherwise we just return the last artifact that matches the platform (if any)

Note: this is a revert to how the logic behaved before https://github.com/jetify-com/opensource/pull/401 but keeps the artifact name improvements from that PR.

cc: @edorizzardi

## How was it tested?

* `runx --install mvdan/gofumpt`
* unit tests