### PR TITLE
docs(readme): add Zig community implementation

### DIFF
--- a/typeid/typeid/README.md
+++ b/typeid/typeid/README.md
@@ -83,6 +83,7 @@ Latest spec version: v0.3.0
 | [T-SQL](https://github.com/uniteeio/typeid_tsql)              | [@uniteeio](https://github.com/uniteeio)                                                  | v0.2 on 2023-08-25                                                         |
 | [TypeScript](https://github.com/ongteckwu/typeid-ts)          | [@ongteckwu](https://github.com/ongteckwu)                                                | v0.2 on 2023-06-30                                                         |
 | [Zig](https://github.com/tensorush/zig-typeid)                | [@tensorush](https://github.com/tensorush)                                                | v0.2 on 2023-07-05                                                         |
+| [Zig](https://github.com/nikoksr/typeid-zig)                | [@nikoksr](https://github.com/nikoksr)                                                | v0.3 on 2024-12-29                                                         |
 
 We are looking for community contributions to implement TypeIDs in other languages.
 

--- a/typeid/typeid/README.md
+++ b/typeid/typeid/README.md
@@ -26,6 +26,7 @@ Here's an example of a TypeID of type `user`:
 A [formal specification](./spec) defines the encoding in more detail.
 
 ## Online Converter
+
 You can try converting UUID to TypeID and back using Jetify's TypeID Converter. Paste your TypeID string to convert to UUID or put your prefix and UUID in this format: `prefix:UUID` to convert to TypeID.
 
 ### [jetify.com/typeid](https://www.jetify.com/typeid)
@@ -82,7 +83,6 @@ Latest spec version: v0.3.0
 | [Swift](https://github.com/Frizlab/swift-typeid)              | [@Frizlab](https://github.com/Frizlab)                                                    | v0.3 on 2024-04-19                                                         |
 | [T-SQL](https://github.com/uniteeio/typeid_tsql)              | [@uniteeio](https://github.com/uniteeio)                                                  | v0.2 on 2023-08-25                                                         |
 | [TypeScript](https://github.com/ongteckwu/typeid-ts)          | [@ongteckwu](https://github.com/ongteckwu)                                                | v0.2 on 2023-06-30                                                         |
-| [Zig](https://github.com/tensorush/zig-typeid)                | [@tensorush](https://github.com/tensorush)                                                | v0.2 on 2023-07-05                                                         |
 | [Zig](https://github.com/nikoksr/typeid-zig)                | [@nikoksr](https://github.com/nikoksr)                                                | v0.3 on 2024-12-29                                                         |
 
 We are looking for community contributions to implement TypeIDs in other languages.


### PR DESCRIPTION
## Summary

Add a new community implementation of the `v0.3` spec for Zig. 

Note: The old `v0.2` implementation for Zig, listed in the readme, 404s when visited as mentioned in [this issue](https://github.com/jetify-com/typeid/issues/38). I wasn't sure whether or not I should remove it from the readme. Let me know and I'll fix it :) cheers.

## How was it tested?

Tests implementation: [here](https://github.com/nikoksr/typeid-zig/blob/44494babb3111de3e472f7f16f88f63caf9a2022/src/typeid.zig#L341-L410)

Last successful CI run: [here](https://github.com/nikoksr/typeid-zig/actions/runs/12536940126/job/34960506375)