### PR TITLE
Add note about license to pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,9 @@
+## Community Contribution License
+All community contributions in this pull request are licensed to the project maintainers
+under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0).
+By creating this pull request I represent that I have the right to license the
+contributions to the project maintainers under the Apache 2 license.
+
 ## Summary
 
 ## How was it tested?


### PR DESCRIPTION
## Summary
Change pull request template so that it adds a note about the Apache license applying to all contributions to `opensource/`

## How was it tested?
Wasn't.