### PR TITLE
[typeid-js] improve type inference for typeid.toString

### DIFF
--- a/typeid/typeid-js/package.json
+++ b/typeid/typeid-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typeid-js",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Official implementation of the TypeID specification in TypeScript. TypeIDs are type-safe, K-sortable, and globally unique identifiers inspired by Stripe IDs",
   "keywords": [
     "typeid",

--- a/typeid/typeid-js/src/typeid.ts
+++ b/typeid/typeid-js/src/typeid.ts
@@ -42,11 +42,11 @@ export class TypeID<const T extends string> {
     return stringify(this.toUUIDBytes());
   }
 
-  public toString(): `${T}_${string}` | string {
+  public toString(): T extends "" ? string : `${T}_${string}` {
     if (this.prefix === "") {
-      return this.suffix;
+      return this.suffix as T extends "" ? string : `${T}_${string}`;
     }
-    return `${this.prefix}_${this.suffix}`;
+    return `${this.prefix}_${this.suffix}` as T extends "" ? string : `${T}_${string}`;
   }
 
   static fromString<const T extends string>(


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0).
By creating this pull request I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 license.

## Summary
Addresses https://github.com/jetify-com/typeid-js/issues/15. The caller is now able to get the exact type based on typeid prefix, since the return type is conditionally determined by `T extends ""`

cc: @programmarchy

## How was it tested?
devbox run test