### PR TITLE
[typeid-js] Add explicitly defined error types

### DIFF
--- a/typeid/typeid-js/src/typeid.ts
+++ b/typeid/typeid-js/src/typeid.ts
@@ -7,6 +7,7 @@ import {
   getType,
   fromString,
 } from "./unboxed/typeid";
+import { TypeIDConversionError } from "./unboxed/error";
 
 export class TypeID<const T extends string> {
   constructor(private prefix: T, private suffix: string = "") {
@@ -27,9 +28,7 @@ export class TypeID<const T extends string> {
   public asType<const U extends string>(prefix: U): TypeID<U> {
     const self = this as unknown as TypeID<U>;
     if (self.prefix !== prefix) {
-      throw new Error(
-        `Cannot convert TypeID of type ${self.prefix} to type ${prefix}`
-      );
+      throw new TypeIDConversionError(self.prefix, prefix);
     }
     return self;
   }

--- a/typeid/typeid-js/src/unboxed/error.ts
+++ b/typeid/typeid-js/src/unboxed/error.ts
@@ -1,0 +1,41 @@
+export class InvalidPrefixError extends Error {
+  constructor(prefix: string) {
+    super(`Invalid prefix "${prefix}". Must be at most 63 ASCII letters [a-z_]`);
+    this.name = "InvalidPrefixError";
+  }
+}
+
+export class PrefixMismatchError extends Error {
+  constructor(expected: string, actual: string) {
+    super(`Invalid TypeId. Prefix mismatch. Expected ${expected}, got ${actual}`);
+    this.name = "PrefixMismatchError";
+  }
+}
+
+export class EmptyPrefixError extends Error {
+  constructor(typeId: string) {
+    super(`Invalid TypeId. Prefix cannot be empty when there's a separator: ${typeId}`);
+    this.name = "EmptyPrefixError";
+  }
+}
+
+export class InvalidSuffixLengthError extends Error {
+  constructor(length: number) {
+    super(`Invalid length. Suffix should have 26 characters, got ${length}`);
+    this.name = "InvalidSuffixLengthError";
+  }
+}
+
+export class InvalidSuffixCharacterError extends Error {
+  constructor(firstChar: string) {
+    super(`Invalid suffix. First character "${firstChar}" must be in the range [0-7]`);
+    this.name = "InvalidSuffixCharacterError";
+  }
+}
+
+export class TypeIDConversionError extends Error {
+  constructor(actualPrefix: string, expectedPrefix: string) {
+    super(`Cannot convert TypeID of type ${actualPrefix} to type ${expectedPrefix}`);
+    this.name = "TypeIDConversionError";
+  }
+}

--- a/typeid/typeid-js/test/typeid.test.ts
+++ b/typeid/typeid-js/test/typeid.test.ts
@@ -3,6 +3,12 @@ import { describe, expect, it } from "@jest/globals";
 import { typeid, TypeID } from "../src/typeid";
 import validJson from "./valid";
 import invalidJson from "./invalid";
+import {
+  InvalidPrefixError,
+  InvalidSuffixCharacterError,
+  InvalidSuffixLengthError,
+  PrefixMismatchError,
+} from "../src/unboxed/error";
 
 describe("TypeID", () => {
   describe("constructor", () => {
@@ -28,15 +34,11 @@ describe("TypeID", () => {
     it("should throw an error if prefix is not lowercase", () => {
       expect(() => {
         typeid("TEST", "00041061050r3gg28a1c60t3gf");
-      }).toThrowError(
-        "Invalid prefix. Must be at most 63 ascii letters [a-z_]"
-      );
+      }).toThrowError(new InvalidPrefixError("TEST"));
 
       expect(() => {
         typeid("  ", "00041061050r3gg28a1c60t3gf");
-      }).toThrowError(
-        "Invalid prefix. Must be at most 63 ascii letters [a-z_]"
-      );
+      }).toThrowError(new InvalidPrefixError("  "));
     });
 
     it("should throw an error if suffix length is not 26", () => {
@@ -111,29 +113,25 @@ describe("TypeID", () => {
 
       expect(() => {
         TypeID.fromString(invalidStr);
-      }).toThrowError(
-        new Error(`Invalid suffix. First character must be in the range [0-7]`)
-      );
+      }).toThrowError(new InvalidSuffixCharacterError("u"));
     });
     it("should throw an error with wrong prefix", () => {
       const str = "prefix_00041061050r3gg28a1c60t3gf";
       expect(() => {
         TypeID.fromString(str, "wrong");
-      }).toThrowError(
-        new Error(`Invalid TypeId. Prefix mismatch. Expected wrong, got prefix`)
-      );
+      }).toThrowError(new PrefixMismatchError("wrong", "prefix"));
     });
     it("should throw an error for empty TypeId string", () => {
       const invalidStr = "";
       expect(() => {
         TypeID.fromString(invalidStr);
-      }).toThrowError(new Error(`Invalid TypeId. Suffix cannot be empty`));
+      }).toThrowError(new InvalidSuffixLengthError(0));
     });
     it("should throw an error for TypeId string with empty suffix", () => {
       const invalidStr = "prefix_";
       expect(() => {
         TypeID.fromString(invalidStr);
-      }).toThrowError(new Error(`Invalid TypeId. Suffix cannot be empty`));
+      }).toThrowError(new InvalidSuffixLengthError(0));
     });
   });
 

--- a/typeid/typeid-js/test/typeid_unboxed.test.ts
+++ b/typeid/typeid-js/test/typeid_unboxed.test.ts
@@ -12,6 +12,11 @@ import {
 } from "../src/unboxed/typeid";
 import validJson from "./valid";
 import invalidJson from "./invalid";
+import {
+  InvalidPrefixError,
+  InvalidSuffixCharacterError,
+  InvalidSuffixLengthError,
+} from "../src/unboxed/error";
 
 describe("TypeId Functions", () => {
   describe("typeidUnboxed", () => {
@@ -38,15 +43,11 @@ describe("TypeId Functions", () => {
     it("should throw an error if prefix is not lowercase", () => {
       expect(() => {
         typeidUnboxed("TEST", "00041061050r3gg28a1c60t3gf");
-      }).toThrowError(
-        "Invalid prefix. Must be at most 63 ascii letters [a-z_]"
-      );
+      }).toThrowError(new InvalidPrefixError("TEST"));
 
       expect(() => {
         typeidUnboxed("  ", "00041061050r3gg28a1c60t3gf");
-      }).toThrowError(
-        "Invalid prefix. Must be at most 63 ascii letters [a-z_]"
-      );
+      }).toThrowError(new InvalidPrefixError("  "));
     });
 
     it("should throw an error if suffix length is not 26", () => {
@@ -80,9 +81,7 @@ describe("TypeId Functions", () => {
 
       expect(() => {
         fromString(invalidStr);
-      }).toThrowError(
-        new Error(`Invalid suffix. First character must be in the range [0-7]`)
-      );
+      }).toThrowError(new InvalidSuffixCharacterError("u"));
     });
 
     it("should throw an error for empty TypeId string", () => {
@@ -90,7 +89,7 @@ describe("TypeId Functions", () => {
 
       expect(() => {
         fromString(invalidStr);
-      }).toThrowError(new Error(`Invalid TypeId. Suffix cannot be empty`));
+      }).toThrowError(new InvalidSuffixLengthError(0));
     });
 
     it("should throw an error for TypeId string with empty suffix", () => {
@@ -98,7 +97,7 @@ describe("TypeId Functions", () => {
 
       expect(() => {
         fromString(invalidStr);
-      }).toThrowError(new Error(`Invalid TypeId. Suffix cannot be empty`));
+      }).toThrowError(new InvalidSuffixLengthError(0));
     });
   });
 


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0).
By creating this pull request I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 license.

## Summary
Addresses https://github.com/jetify-com/typeid-js/issues/14

cc: @elieven

## How was it tested?
devbox run test
