### PR TITLE
Replace go.jetpack.io with go.jetify.com

### DIFF
--- a/api/buf.gen.yaml
+++ b/api/buf.gen.yaml
@@ -5,7 +5,7 @@ managed:
   enabled: true
   override:
     - file_option: go_package_prefix
-      value: go.jetpack.io/axiom/api/gen
+      value: go.jetify.com/axiom/api/gen
 inputs:
   - directory: proto
   - module: buf.build/googleapis/googleapis

--- a/api/go/gen/pub/sandbox/v1alpha1/sandboxv1alpha1connect/sandbox.connect.go
+++ b/api/go/gen/pub/sandbox/v1alpha1/sandboxv1alpha1connect/sandbox.connect.go
@@ -11,7 +11,7 @@ import (
 	connect "connectrpc.com/connect"
 	context "context"
 	errors "errors"
-	v1alpha1 "go.jetpack.io/axiom/api/gen/pub/sandbox/v1alpha1"
+	v1alpha1 "go.jetify.com/axiom/api/gen/pub/sandbox/v1alpha1"
 	http "net/http"
 	strings "strings"
 )

--- a/devbox.json
+++ b/devbox.json
@@ -5,7 +5,7 @@
   "shell": {
     "scripts": {
       "update-internal-deps": [
-        "for_each_gomod go get -u go.jetpack.io/pkg@main go.jetify.com/typeid@main || true",
+        "for_each_gomod go get -u go.jetify.com/pkg@main go.jetify.com/typeid@main || true",
         "devbox run tidy"
       ]
     }

--- a/envsec/.goreleaser.yaml
+++ b/envsec/.goreleaser.yaml
@@ -12,9 +12,9 @@ builds:
     mod_timestamp: "{{ .CommitTimestamp }}" # For reproducible builds
     ldflags:
       - -s -w # Strip debug 
-      - -X go.jetpack.io/envsec/internal/build.Version={{.Version}}
-      - -X go.jetpack.io/envsec/internal/build.Commit={{.Commit}}
-      - -X go.jetpack.io/envsec/internal/build.CommitDate={{.CommitDate}}
+      - -X go.jetify.com/envsec/internal/build.Version={{.Version}}
+      - -X go.jetify.com/envsec/internal/build.Commit={{.Commit}}
+      - -X go.jetify.com/envsec/internal/build.CommitDate={{.CommitDate}}
     env:
       - CGO_ENABLED=0
       - GO111MODULE=on

--- a/envsec/cmd/envsec/main.go
+++ b/envsec/cmd/envsec/main.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"os"
 
-	"go.jetpack.io/envsec/pkg/envcli"
+	"go.jetify.com/envsec/pkg/envcli"
 )
 
 func main() {

--- a/envsec/go.mod
+++ b/envsec/go.mod
@@ -1,4 +1,4 @@
-module go.jetpack.io/envsec
+module go.jetify.com/envsec
 
 go 1.23
 
@@ -24,7 +24,7 @@ require (
 	github.com/samber/lo v1.39.0
 	github.com/spf13/cobra v1.8.0
 	go.jetify.com/typeid v1.3.1-0.20241211224430-39758d55f188
-	go.jetpack.io/pkg v0.0.0-20250222021558-d8c54e43d747
+	go.jetify.com/pkg v0.0.0-20250222021558-d8c54e43d747
 	golang.org/x/text v0.14.0
 )
 

--- a/envsec/go.sum
+++ b/envsec/go.sum
@@ -141,8 +141,8 @@ github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 go.jetify.com/typeid v1.3.1-0.20241211224430-39758d55f188 h1:gLbyaE7KA2/qqUSw5j9RweZ2tZvM4nSVOCFXrWSPo7c=
 go.jetify.com/typeid v1.3.1-0.20241211224430-39758d55f188/go.mod h1:Qlbkqu/YQVknz7AhsKUnDJDmOfKR6G/YUiEbxt12PXY=
-go.jetpack.io/pkg v0.0.0-20250222021558-d8c54e43d747 h1:RZx7SBvb3WTYVPQpVahDdZkphHAkEZV+GkYStkatPG4=
-go.jetpack.io/pkg v0.0.0-20250222021558-d8c54e43d747/go.mod h1:YpbOzlAy8v8lUKOKIx/FrqBmiVzNt8J6HSFeleMLeYw=
+go.jetify.com/pkg v0.0.0-20250222021558-d8c54e43d747 h1:RZx7SBvb3WTYVPQpVahDdZkphHAkEZV+GkYStkatPG4=
+go.jetify.com/pkg v0.0.0-20250222021558-d8c54e43d747/go.mod h1:YpbOzlAy8v8lUKOKIx/FrqBmiVzNt8J6HSFeleMLeYw=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.19.0/go.mod h1:Iy9bg/ha4yyC70EfRS8jz+B6ybOBKMaSxLj6P6oBDfU=

--- a/envsec/internal/flow/init.go
+++ b/envsec/internal/flow/init.go
@@ -11,13 +11,13 @@ import (
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/fatih/color"
+	"go.jetify.com/envsec/internal/git"
+	"go.jetify.com/pkg/api"
+	membersv1alpha1 "go.jetify.com/pkg/api/gen/priv/members/v1alpha1"
+	projectsv1alpha1 "go.jetify.com/pkg/api/gen/priv/projects/v1alpha1"
+	"go.jetify.com/pkg/auth/session"
+	"go.jetify.com/pkg/id"
 	"go.jetify.com/typeid"
-	"go.jetpack.io/envsec/internal/git"
-	"go.jetpack.io/pkg/api"
-	membersv1alpha1 "go.jetpack.io/pkg/api/gen/priv/members/v1alpha1"
-	projectsv1alpha1 "go.jetpack.io/pkg/api/gen/priv/projects/v1alpha1"
-	"go.jetpack.io/pkg/auth/session"
-	"go.jetpack.io/pkg/id"
 )
 
 // flow:

--- a/envsec/pkg/awsfed/awsfed.go
+++ b/envsec/pkg/awsfed/awsfed.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/cognitoidentity"
 	"github.com/aws/aws-sdk-go-v2/service/cognitoidentity/types"
-	"go.jetpack.io/pkg/auth/session"
-	"go.jetpack.io/pkg/envvar"
-	"go.jetpack.io/pkg/filecache"
+	"go.jetify.com/pkg/auth/session"
+	"go.jetify.com/pkg/envvar"
+	"go.jetify.com/pkg/filecache"
 )
 
 const cacheKeyPrefix = "awsfed"

--- a/envsec/pkg/envcli/auth.go
+++ b/envsec/pkg/envcli/auth.go
@@ -8,9 +8,9 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"go.jetpack.io/envsec/internal/build"
-	"go.jetpack.io/pkg/auth"
-	"go.jetpack.io/pkg/envvar"
+	"go.jetify.com/envsec/internal/build"
+	"go.jetify.com/pkg/auth"
+	"go.jetify.com/pkg/envvar"
 )
 
 func authCmd() *cobra.Command {

--- a/envsec/pkg/envcli/download.go
+++ b/envsec/pkg/envcli/download.go
@@ -6,7 +6,7 @@ package envcli
 import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"go.jetpack.io/envsec/pkg/envsec"
+	"go.jetify.com/envsec/pkg/envsec"
 )
 
 type downloadCmdFlags struct {

--- a/envsec/pkg/envcli/flags.go
+++ b/envsec/pkg/envcli/flags.go
@@ -10,12 +10,12 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"go.jetify.com/typeid"
-	"go.jetpack.io/envsec/internal/build"
-	"go.jetpack.io/envsec/pkg/envsec"
-	"go.jetpack.io/envsec/pkg/stores/jetstore"
-	"go.jetpack.io/envsec/pkg/stores/ssmstore"
-	"go.jetpack.io/pkg/envvar"
-	"go.jetpack.io/pkg/id"
+	"go.jetify.com/envsec/internal/build"
+	"go.jetify.com/envsec/pkg/envsec"
+	"go.jetify.com/envsec/pkg/stores/jetstore"
+	"go.jetify.com/envsec/pkg/stores/ssmstore"
+	"go.jetify.com/pkg/envvar"
+	"go.jetify.com/pkg/id"
 )
 
 // to be composed into xyzCmdFlags structs

--- a/envsec/pkg/envcli/init.go
+++ b/envsec/pkg/envcli/init.go
@@ -4,9 +4,9 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"go.jetpack.io/envsec/internal/build"
-	"go.jetpack.io/envsec/pkg/envsec"
-	"go.jetpack.io/pkg/envvar"
+	"go.jetify.com/envsec/internal/build"
+	"go.jetify.com/envsec/pkg/envsec"
+	"go.jetify.com/pkg/envvar"
 )
 
 type initCmdFlags struct {

--- a/envsec/pkg/envcli/ls.go
+++ b/envsec/pkg/envcli/ls.go
@@ -5,7 +5,7 @@ package envcli
 
 import (
 	"github.com/spf13/cobra"
-	"go.jetpack.io/envsec/pkg/envsec"
+	"go.jetify.com/envsec/pkg/envsec"
 )
 
 const environmentFlagName = "environment"

--- a/envsec/pkg/envcli/set.go
+++ b/envsec/pkg/envcli/set.go
@@ -6,7 +6,7 @@ package envcli
 import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"go.jetpack.io/envsec/pkg/envsec"
+	"go.jetify.com/envsec/pkg/envsec"
 )
 
 type setCmdFlags struct {

--- a/envsec/pkg/envcli/upload.go
+++ b/envsec/pkg/envcli/upload.go
@@ -5,7 +5,7 @@ package envcli
 
 import (
 	"github.com/spf13/cobra"
-	"go.jetpack.io/envsec/pkg/envsec"
+	"go.jetify.com/envsec/pkg/envsec"
 )
 
 type uploadCmdFlags struct {

--- a/envsec/pkg/envcli/usage.go
+++ b/envsec/pkg/envcli/usage.go
@@ -6,7 +6,7 @@ package envcli
 import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
-	"go.jetpack.io/envsec/internal/tux"
+	"go.jetify.com/envsec/internal/tux"
 )
 
 // TODO: move to file

--- a/envsec/pkg/envcli/version.go
+++ b/envsec/pkg/envcli/version.go
@@ -8,7 +8,7 @@ import (
 	"runtime"
 
 	"github.com/spf13/cobra"
-	"go.jetpack.io/envsec/internal/build"
+	"go.jetify.com/envsec/internal/build"
 )
 
 type versionFlags struct {

--- a/envsec/pkg/envsec/auth.go
+++ b/envsec/pkg/envsec/auth.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"io"
 
-	"go.jetpack.io/pkg/api"
-	"go.jetpack.io/pkg/auth"
+	"go.jetify.com/pkg/api"
+	"go.jetify.com/pkg/auth"
 )
 
 func (e *Envsec) AuthClient() (*auth.Client, error) {

--- a/envsec/pkg/envsec/delete.go
+++ b/envsec/pkg/envsec/delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"strings"
 
-	"go.jetpack.io/envsec/internal/tux"
+	"go.jetify.com/envsec/internal/tux"
 )
 
 func (e *Envsec) DeleteAll(ctx context.Context, envNames ...string) error {

--- a/envsec/pkg/envsec/download.go
+++ b/envsec/pkg/envsec/download.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/joho/godotenv"
 	"github.com/pkg/errors"
-	"go.jetpack.io/envsec/internal/tux"
+	"go.jetify.com/envsec/internal/tux"
 )
 
 // Download downloads the environment variables for the environment specified.

--- a/envsec/pkg/envsec/envsec.go
+++ b/envsec/pkg/envsec/envsec.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"go.jetpack.io/pkg/auth/session"
+	"go.jetify.com/pkg/auth/session"
 )
 
 type Envsec struct {

--- a/envsec/pkg/envsec/init.go
+++ b/envsec/pkg/envsec/init.go
@@ -8,10 +8,10 @@ import (
 	"path/filepath"
 
 	"go.jetify.com/typeid"
-	"go.jetpack.io/envsec/internal/flow"
-	"go.jetpack.io/envsec/internal/git"
-	"go.jetpack.io/pkg/api"
-	"go.jetpack.io/pkg/id"
+	"go.jetify.com/envsec/internal/flow"
+	"go.jetify.com/envsec/internal/git"
+	"go.jetify.com/pkg/api"
+	"go.jetify.com/pkg/id"
 )
 
 var (

--- a/envsec/pkg/envsec/list.go
+++ b/envsec/pkg/envsec/list.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/olekukonko/tablewriter"
 	"github.com/pkg/errors"
-	"go.jetpack.io/envsec/internal/tux"
+	"go.jetify.com/envsec/internal/tux"
 )
 
 func (e *Envsec) List(ctx context.Context) ([]EnvVar, error) {

--- a/envsec/pkg/envsec/projects.go
+++ b/envsec/pkg/envsec/projects.go
@@ -5,9 +5,9 @@ import (
 	"io"
 
 	"connectrpc.com/connect"
-	"go.jetpack.io/envsec/internal/tux"
-	"go.jetpack.io/pkg/api"
-	v1alpha1 "go.jetpack.io/pkg/api/gen/priv/projects/v1alpha1"
+	"go.jetify.com/envsec/internal/tux"
+	"go.jetify.com/pkg/api"
+	v1alpha1 "go.jetify.com/pkg/api/gen/priv/projects/v1alpha1"
 )
 
 func (e *Envsec) DescribeCurrentProject(

--- a/envsec/pkg/envsec/set.go
+++ b/envsec/pkg/envsec/set.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/samber/lo"
-	"go.jetpack.io/envsec/internal/tux"
+	"go.jetify.com/envsec/internal/tux"
 )
 
 func (e *Envsec) Set(ctx context.Context, name string, value string) error {

--- a/envsec/pkg/envsec/store.go
+++ b/envsec/pkg/envsec/store.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 
-	"go.jetpack.io/pkg/auth/session"
+	"go.jetify.com/pkg/auth/session"
 )
 
 // Uniquely identifies an environment in which we store environment variables.

--- a/envsec/pkg/envsec/upload.go
+++ b/envsec/pkg/envsec/upload.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/joho/godotenv"
 	"github.com/pkg/errors"
-	"go.jetpack.io/pkg/fileutil"
+	"go.jetify.com/pkg/fileutil"
 )
 
 // Upload uploads the environment variables for the environment specified from

--- a/envsec/pkg/stores/jetstore/jetstore.go
+++ b/envsec/pkg/stores/jetstore/jetstore.go
@@ -4,11 +4,11 @@ import (
 	"context"
 
 	"connectrpc.com/connect"
-	"go.jetpack.io/envsec/pkg/envsec"
-	"go.jetpack.io/pkg/api"
-	secretsv1alpha1 "go.jetpack.io/pkg/api/gen/priv/secrets/v1alpha1"
-	"go.jetpack.io/pkg/api/gen/priv/secrets/v1alpha1/secretsv1alpha1connect"
-	"go.jetpack.io/pkg/auth/session"
+	"go.jetify.com/envsec/pkg/envsec"
+	"go.jetify.com/pkg/api"
+	secretsv1alpha1 "go.jetify.com/pkg/api/gen/priv/secrets/v1alpha1"
+	"go.jetify.com/pkg/api/gen/priv/secrets/v1alpha1/secretsv1alpha1connect"
+	"go.jetify.com/pkg/auth/session"
 )
 
 type JetpackAPIStore struct {

--- a/envsec/pkg/stores/ssmstore/config.go
+++ b/envsec/pkg/stores/ssmstore/config.go
@@ -3,7 +3,7 @@ package ssmstore
 import (
 	"path"
 
-	"go.jetpack.io/envsec/pkg/envsec"
+	"go.jetify.com/envsec/pkg/envsec"
 )
 
 const pathPrefix = "/jetpack-data/env"

--- a/envsec/pkg/stores/ssmstore/parameter_store.go
+++ b/envsec/pkg/stores/ssmstore/parameter_store.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	"github.com/samber/lo"
-	"go.jetpack.io/envsec/pkg/envsec"
+	"go.jetify.com/envsec/pkg/envsec"
 	"golang.org/x/text/collate"
 	"golang.org/x/text/language"
 )

--- a/envsec/pkg/stores/ssmstore/ssmstore.go
+++ b/envsec/pkg/stores/ssmstore/ssmstore.go
@@ -11,9 +11,9 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	"github.com/samber/lo"
-	"go.jetpack.io/envsec/pkg/awsfed"
-	"go.jetpack.io/envsec/pkg/envsec"
-	"go.jetpack.io/pkg/auth/session"
+	"go.jetify.com/envsec/pkg/awsfed"
+	"go.jetify.com/envsec/pkg/envsec"
+	"go.jetify.com/pkg/auth/session"
 )
 
 type SSMStore struct {

--- a/pkg/api/buf.gen.yaml
+++ b/pkg/api/buf.gen.yaml
@@ -2,7 +2,7 @@ version: v1
 managed:
   enabled: true
   go_package_prefix:
-    default: go.jetpack.io/pkg/api/gen
+    default: go.jetify.com/pkg/api/gen
 
 plugins:
   - plugin: go

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"sync"
 
-	"go.jetpack.io/pkg/api/gen/priv/members/v1alpha1/membersv1alpha1connect"
-	"go.jetpack.io/pkg/api/gen/priv/nix/v1alpha1/nixv1alpha1connect"
-	"go.jetpack.io/pkg/api/gen/priv/projects/v1alpha1/projectsv1alpha1connect"
-	"go.jetpack.io/pkg/api/gen/priv/secrets/v1alpha1/secretsv1alpha1connect"
-	"go.jetpack.io/pkg/api/gen/priv/tokenservice/v1alpha1/tokenservicev1alpha1connect"
-	"go.jetpack.io/pkg/auth/session"
+	"go.jetify.com/pkg/api/gen/priv/members/v1alpha1/membersv1alpha1connect"
+	"go.jetify.com/pkg/api/gen/priv/nix/v1alpha1/nixv1alpha1connect"
+	"go.jetify.com/pkg/api/gen/priv/projects/v1alpha1/projectsv1alpha1connect"
+	"go.jetify.com/pkg/api/gen/priv/secrets/v1alpha1/secretsv1alpha1connect"
+	"go.jetify.com/pkg/api/gen/priv/tokenservice/v1alpha1/tokenservicev1alpha1connect"
+	"go.jetify.com/pkg/auth/session"
 	"golang.org/x/oauth2"
 )
 

--- a/pkg/api/gen/priv/members/v1alpha1/members.pb.go
+++ b/pkg/api/gen/priv/members/v1alpha1/members.pb.go
@@ -10,7 +10,7 @@
 package membersv1alpha1
 
 import (
-	v1alpha1 "go.jetpack.io/pkg/api/gen/priv/organizations/v1alpha1"
+	v1alpha1 "go.jetify.com/pkg/api/gen/priv/organizations/v1alpha1"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"

--- a/pkg/api/gen/priv/members/v1alpha1/membersv1alpha1connect/members.connect.go
+++ b/pkg/api/gen/priv/members/v1alpha1/membersv1alpha1connect/members.connect.go
@@ -11,7 +11,7 @@ import (
 	connect "connectrpc.com/connect"
 	context "context"
 	errors "errors"
-	v1alpha1 "go.jetpack.io/pkg/api/gen/priv/members/v1alpha1"
+	v1alpha1 "go.jetify.com/pkg/api/gen/priv/members/v1alpha1"
 	http "net/http"
 	strings "strings"
 )

--- a/pkg/api/gen/priv/nix/v1alpha1/nixv1alpha1connect/nix.connect.go
+++ b/pkg/api/gen/priv/nix/v1alpha1/nixv1alpha1connect/nix.connect.go
@@ -11,7 +11,7 @@ import (
 	connect "connectrpc.com/connect"
 	context "context"
 	errors "errors"
-	v1alpha1 "go.jetpack.io/pkg/api/gen/priv/nix/v1alpha1"
+	v1alpha1 "go.jetify.com/pkg/api/gen/priv/nix/v1alpha1"
 	http "net/http"
 	strings "strings"
 )

--- a/pkg/api/gen/priv/organizations/v1alpha1/organizationsv1alpha1connect/organizations.connect.go
+++ b/pkg/api/gen/priv/organizations/v1alpha1/organizationsv1alpha1connect/organizations.connect.go
@@ -11,7 +11,7 @@ import (
 	connect "connectrpc.com/connect"
 	context "context"
 	errors "errors"
-	v1alpha1 "go.jetpack.io/pkg/api/gen/priv/organizations/v1alpha1"
+	v1alpha1 "go.jetify.com/pkg/api/gen/priv/organizations/v1alpha1"
 	http "net/http"
 	strings "strings"
 )

--- a/pkg/api/gen/priv/projects/v1alpha1/projectsv1alpha1connect/projects.connect.go
+++ b/pkg/api/gen/priv/projects/v1alpha1/projectsv1alpha1connect/projects.connect.go
@@ -17,7 +17,7 @@ import (
 	connect "connectrpc.com/connect"
 	context "context"
 	errors "errors"
-	v1alpha1 "go.jetpack.io/pkg/api/gen/priv/projects/v1alpha1"
+	v1alpha1 "go.jetify.com/pkg/api/gen/priv/projects/v1alpha1"
 	http "net/http"
 	strings "strings"
 )

--- a/pkg/api/gen/priv/secrets/v1alpha1/secretsv1alpha1connect/secrets.connect.go
+++ b/pkg/api/gen/priv/secrets/v1alpha1/secretsv1alpha1connect/secrets.connect.go
@@ -8,7 +8,7 @@ import (
 	connect "connectrpc.com/connect"
 	context "context"
 	errors "errors"
-	v1alpha1 "go.jetpack.io/pkg/api/gen/priv/secrets/v1alpha1"
+	v1alpha1 "go.jetify.com/pkg/api/gen/priv/secrets/v1alpha1"
 	http "net/http"
 	strings "strings"
 )

--- a/pkg/api/gen/priv/tokenservice/v1alpha1/tokenservicev1alpha1connect/tokenservice.connect.go
+++ b/pkg/api/gen/priv/tokenservice/v1alpha1/tokenservicev1alpha1connect/tokenservice.connect.go
@@ -11,7 +11,7 @@ import (
 	connect "connectrpc.com/connect"
 	context "context"
 	errors "errors"
-	v1alpha1 "go.jetpack.io/pkg/api/gen/priv/tokenservice/v1alpha1"
+	v1alpha1 "go.jetify.com/pkg/api/gen/priv/tokenservice/v1alpha1"
 	http "net/http"
 	strings "strings"
 )

--- a/pkg/api/members.go
+++ b/pkg/api/members.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"connectrpc.com/connect"
-	membersv1alpha1 "go.jetpack.io/pkg/api/gen/priv/members/v1alpha1"
+	membersv1alpha1 "go.jetify.com/pkg/api/gen/priv/members/v1alpha1"
 )
 
 func (c *Client) GetMember(

--- a/pkg/api/nix.go
+++ b/pkg/api/nix.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"connectrpc.com/connect"
-	nixv1alpha1 "go.jetpack.io/pkg/api/gen/priv/nix/v1alpha1"
+	nixv1alpha1 "go.jetify.com/pkg/api/gen/priv/nix/v1alpha1"
 )
 
 func (c *Client) GetAWSCredentials(ctx context.Context) (*nixv1alpha1.AWSCredentials, error) {

--- a/pkg/api/projects.go
+++ b/pkg/api/projects.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"connectrpc.com/connect"
-	projectsv1alpha1 "go.jetpack.io/pkg/api/gen/priv/projects/v1alpha1"
-	"go.jetpack.io/pkg/id"
+	projectsv1alpha1 "go.jetify.com/pkg/api/gen/priv/projects/v1alpha1"
+	"go.jetify.com/pkg/id"
 )
 
 func (c *Client) ListProjects(

--- a/pkg/api/secrets.go
+++ b/pkg/api/secrets.go
@@ -1,7 +1,7 @@
 package api
 
 import (
-	"go.jetpack.io/pkg/api/gen/priv/secrets/v1alpha1/secretsv1alpha1connect"
+	"go.jetify.com/pkg/api/gen/priv/secrets/v1alpha1/secretsv1alpha1connect"
 )
 
 func (c *Client) SecretsService() secretsv1alpha1connect.SecretsServiceClient {

--- a/pkg/api/tokens.go
+++ b/pkg/api/tokens.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"connectrpc.com/connect"
-	tokenservicev1alpha1 "go.jetpack.io/pkg/api/gen/priv/tokenservice/v1alpha1"
-	"go.jetpack.io/pkg/ids"
+	tokenservicev1alpha1 "go.jetify.com/pkg/api/gen/priv/tokenservice/v1alpha1"
+	"go.jetify.com/pkg/ids"
 )
 
 func (c *Client) GetAccessToken(

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -7,12 +7,12 @@ import (
 	"path/filepath"
 
 	"github.com/coreos/go-oidc/v3/oidc"
-	"go.jetpack.io/pkg/auth/session"
+	"go.jetify.com/pkg/auth/session"
 	"golang.org/x/oauth2"
 
-	"go.jetpack.io/pkg/auth/internal/authflow"
-	"go.jetpack.io/pkg/auth/internal/callbackserver"
-	"go.jetpack.io/pkg/auth/internal/tokenstore"
+	"go.jetify.com/pkg/auth/internal/authflow"
+	"go.jetify.com/pkg/auth/internal/callbackserver"
+	"go.jetify.com/pkg/auth/internal/tokenstore"
 )
 
 var ErrNotLoggedIn = fmt.Errorf("not logged in")

--- a/pkg/auth/cmd/auth/cli/login.go
+++ b/pkg/auth/cmd/auth/cli/login.go
@@ -9,8 +9,8 @@ import (
 	"github.com/hokaccha/go-prettyjson"
 	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
-	"go.jetpack.io/pkg/auth"
-	"go.jetpack.io/pkg/auth/session"
+	"go.jetify.com/pkg/auth"
+	"go.jetify.com/pkg/auth/session"
 )
 
 type sharedFlags struct {

--- a/pkg/auth/cmd/auth/main.go
+++ b/pkg/auth/cmd/auth/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "go.jetpack.io/pkg/auth/cmd/auth/cli"
+import "go.jetify.com/pkg/auth/cmd/auth/cli"
 
 func main() {
 	cli.Main()

--- a/pkg/auth/internal/authflow/authflow.go
+++ b/pkg/auth/internal/authflow/authflow.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/pkg/browser"
-	"go.jetpack.io/pkg/auth/internal/pkce"
-	"go.jetpack.io/pkg/auth/session"
+	"go.jetify.com/pkg/auth/internal/pkce"
+	"go.jetify.com/pkg/auth/session"
 	"golang.org/x/oauth2"
 )
 

--- a/pkg/auth/internal/authflow/init.go
+++ b/pkg/auth/internal/authflow/init.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/coreos/go-oidc/v3/oidc"
-	"go.jetpack.io/pkg/auth/internal/callbackserver"
+	"go.jetify.com/pkg/auth/internal/callbackserver"
 	"golang.org/x/oauth2"
 )
 

--- a/pkg/auth/internal/authflow/url.go
+++ b/pkg/auth/internal/authflow/url.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 
 	"github.com/coreos/go-oidc/v3/oidc"
-	"go.jetpack.io/pkg/auth/internal/pkce"
+	"go.jetify.com/pkg/auth/internal/pkce"
 	"golang.org/x/oauth2"
 )
 

--- a/pkg/auth/internal/tokenstore/tokenstore.go
+++ b/pkg/auth/internal/tokenstore/tokenstore.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"os"
 
-	"go.jetpack.io/pkg/auth/session"
+	"go.jetify.com/pkg/auth/session"
 )
 
 const storeDataVersion = "1"

--- a/pkg/auth/refreshable.go
+++ b/pkg/auth/refreshable.go
@@ -3,7 +3,7 @@ package auth
 import (
 	"context"
 
-	"go.jetpack.io/pkg/auth/session"
+	"go.jetify.com/pkg/auth/session"
 )
 
 // Implements something similar to oauth2.TokenSource, but with a session.Token

--- a/pkg/cachehash/hash.go
+++ b/pkg/cachehash/hash.go
@@ -17,7 +17,7 @@ import (
 	"strings"
 
 	"github.com/gosimple/slug"
-	"go.jetpack.io/pkg/redact"
+	"go.jetify.com/pkg/redact"
 )
 
 // Bytes returns a hex-encoded hash of b.

--- a/pkg/filecache/filecache.go
+++ b/pkg/filecache/filecache.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"go.jetpack.io/pkg/cachehash"
+	"go.jetify.com/pkg/cachehash"
 )
 
 var (

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -1,4 +1,4 @@
-module go.jetpack.io/pkg
+module go.jetify.com/pkg
 
 go 1.23
 

--- a/pkg/runx/cmd/pkg/cli/releases.go
+++ b/pkg/runx/cmd/pkg/cli/releases.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/k0kubun/pp"
 	"github.com/spf13/cobra"
-	"go.jetpack.io/pkg/runx/impl/github"
-	"go.jetpack.io/pkg/runx/impl/types"
+	"go.jetify.com/pkg/runx/impl/github"
+	"go.jetify.com/pkg/runx/impl/types"
 )
 
 func ReleasesCmd() *cobra.Command {

--- a/pkg/runx/cmd/pkg/cli/resolve.go
+++ b/pkg/runx/cmd/pkg/cli/resolve.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/k0kubun/pp"
 	"github.com/spf13/cobra"
-	"go.jetpack.io/pkg/runx/impl/registry"
-	"go.jetpack.io/pkg/runx/impl/types"
+	"go.jetify.com/pkg/runx/impl/registry"
+	"go.jetify.com/pkg/runx/impl/types"
 )
 
 func ResolveCmd() *cobra.Command {

--- a/pkg/runx/cmd/pkg/main.go
+++ b/pkg/runx/cmd/pkg/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "go.jetpack.io/pkg/runx/cmd/pkg/cli"
+import "go.jetify.com/pkg/runx/cmd/pkg/cli"
 
 func main() {
 	cli.Main()

--- a/pkg/runx/cmd/runx/cli/root.go
+++ b/pkg/runx/cmd/runx/cli/root.go
@@ -7,7 +7,7 @@ import (
 	"os"
 
 	"github.com/fatih/color"
-	"go.jetpack.io/pkg/runx/impl/runx"
+	"go.jetify.com/pkg/runx/impl/runx"
 )
 
 func Help() {

--- a/pkg/runx/cmd/runx/main.go
+++ b/pkg/runx/cmd/runx/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "go.jetpack.io/pkg/runx/cmd/runx/cli"
+import "go.jetify.com/pkg/runx/cmd/runx/cli"
 
 func main() {
 	cli.Main()

--- a/pkg/runx/impl/download/download.go
+++ b/pkg/runx/impl/download/download.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/cavaliergopher/grab/v3"
-	"go.jetpack.io/pkg/fileutil"
+	"go.jetify.com/pkg/fileutil"
 )
 
 type Client struct {

--- a/pkg/runx/impl/github/convert.go
+++ b/pkg/runx/impl/github/convert.go
@@ -2,7 +2,7 @@ package github
 
 import (
 	githubimpl "github.com/google/go-github/v53/github"
-	"go.jetpack.io/pkg/runx/impl/types"
+	"go.jetify.com/pkg/runx/impl/types"
 )
 
 func convertGithubReleases(releases []*githubimpl.RepositoryRelease) []types.ReleaseMetadata {

--- a/pkg/runx/impl/github/github.go
+++ b/pkg/runx/impl/github/github.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 
 	githubimpl "github.com/google/go-github/v53/github"
-	"go.jetpack.io/pkg/runx/impl/httpcacher"
-	"go.jetpack.io/pkg/runx/impl/types"
+	"go.jetify.com/pkg/runx/impl/httpcacher"
+	"go.jetify.com/pkg/runx/impl/types"
 	"golang.org/x/oauth2"
 )
 

--- a/pkg/runx/impl/registry/artifact.go
+++ b/pkg/runx/impl/registry/artifact.go
@@ -4,7 +4,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"go.jetpack.io/pkg/runx/impl/types"
+	"go.jetify.com/pkg/runx/impl/types"
 )
 
 func findArtifactForPlatform(artifacts []types.ArtifactMetadata, platform types.Platform) (types.ArtifactMetadata, error) {

--- a/pkg/runx/impl/registry/extract.go
+++ b/pkg/runx/impl/registry/extract.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/codeclysm/extract/v3"
-	"go.jetpack.io/pkg/fileutil"
+	"go.jetify.com/pkg/fileutil"
 )
 
 func Extract(ctx context.Context, src string, dest string) error {

--- a/pkg/runx/impl/registry/json_io.go
+++ b/pkg/runx/impl/registry/json_io.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"time"
 
-	"go.jetpack.io/pkg/fileutil"
+	"go.jetify.com/pkg/fileutil"
 )
 
 // TODO: Generalize package by:

--- a/pkg/runx/impl/registry/registry.go
+++ b/pkg/runx/impl/registry/registry.go
@@ -6,10 +6,10 @@ import (
 	"os"
 	"path/filepath"
 
-	"go.jetpack.io/pkg/fileutil"
-	"go.jetpack.io/pkg/runx/impl/download"
-	"go.jetpack.io/pkg/runx/impl/github"
-	"go.jetpack.io/pkg/runx/impl/types"
+	"go.jetify.com/pkg/fileutil"
+	"go.jetify.com/pkg/runx/impl/download"
+	"go.jetify.com/pkg/runx/impl/github"
+	"go.jetify.com/pkg/runx/impl/types"
 )
 
 var xdgInstallationSubdir = "runx/pkgs"

--- a/pkg/runx/impl/registry/registry_test.go
+++ b/pkg/runx/impl/registry/registry_test.go
@@ -6,7 +6,7 @@ import (
 	"slices"
 	"testing"
 
-	"go.jetpack.io/pkg/runx/impl/types"
+	"go.jetify.com/pkg/runx/impl/types"
 )
 
 func TestIsBinary(t *testing.T) {

--- a/pkg/runx/impl/runx/install.go
+++ b/pkg/runx/impl/runx/install.go
@@ -3,8 +3,8 @@ package runx
 import (
 	"context"
 
-	"go.jetpack.io/pkg/runx/impl/registry"
-	"go.jetpack.io/pkg/runx/impl/types"
+	"go.jetify.com/pkg/runx/impl/registry"
+	"go.jetify.com/pkg/runx/impl/types"
 )
 
 func (r *RunX) Install(ctx context.Context, pkgs ...string) ([]string, error) {

--- a/pkg/runx/impl/runx/run.go
+++ b/pkg/runx/impl/runx/run.go
@@ -7,7 +7,7 @@ import (
 	"os/exec"
 	"strings"
 
-	"go.jetpack.io/pkg/runx/impl/types"
+	"go.jetify.com/pkg/runx/impl/types"
 )
 
 func (r *RunX) Run(ctx context.Context, args ...string) error {

--- a/pkg/runx/impl/types/pkgref_test.go
+++ b/pkg/runx/impl/types/pkgref_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"go.jetpack.io/pkg/runx/impl/types"
+	"go.jetify.com/pkg/runx/impl/types"
 )
 
 func TestFromString_Valid(t *testing.T) {

--- a/typeid/typeid/go.mod
+++ b/typeid/typeid/go.mod
@@ -1,4 +1,4 @@
-module go.jetpack.io/typeid-cli
+module go.jetify.com/typeid-cli
 
 go 1.23
 

--- a/typeid/typeid/main.go
+++ b/typeid/typeid/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "go.jetpack.io/typeid-cli/cli"
+import "go.jetify.com/typeid-cli/cli"
 
 func main() {
 	cli.Main()

--- a/tyson/api/eval.go
+++ b/tyson/api/eval.go
@@ -3,7 +3,7 @@ package api
 import (
 	"encoding/json"
 
-	"go.jetpack.io/tyson/internal/interpreter"
+	"go.jetify.com/tyson/internal/interpreter"
 )
 
 func Eval(inputPath string) ([]byte, error) {

--- a/tyson/cmd/tyson/cli/eval.go
+++ b/tyson/cmd/tyson/cli/eval.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hokaccha/go-prettyjson"
 	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
-	"go.jetpack.io/tyson"
+	"go.jetify.com/tyson"
 )
 
 func EvalCmd() *cobra.Command {

--- a/tyson/cmd/tyson/cli/root.go
+++ b/tyson/cmd/tyson/cli/root.go
@@ -7,7 +7,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"go.jetpack.io/tyson/msgerror"
+	"go.jetify.com/tyson/msgerror"
 )
 
 func RootCmd() *cobra.Command {

--- a/tyson/cmd/tyson/main.go
+++ b/tyson/cmd/tyson/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "go.jetpack.io/tyson/cmd/tyson/cli"
+import "go.jetify.com/tyson/cmd/tyson/cli"
 
 func main() {
 	cli.Main()

--- a/tyson/go.mod
+++ b/tyson/go.mod
@@ -1,4 +1,4 @@
-module go.jetpack.io/tyson
+module go.jetify.com/tyson
 
 go 1.23
 

--- a/tyson/internal/interpreter/interpreter.go
+++ b/tyson/internal/interpreter/interpreter.go
@@ -3,7 +3,7 @@ package interpreter
 import (
 	"github.com/dop251/goja"
 	"github.com/evanw/esbuild/pkg/api"
-	"go.jetpack.io/tyson/internal/tsembed"
+	"go.jetify.com/tyson/internal/tsembed"
 )
 
 func Eval(entrypoint string) (goja.Value, error) {

--- a/tyson/internal/tsembed/tsembed.go
+++ b/tyson/internal/tsembed/tsembed.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/dop251/goja"
 	"github.com/evanw/esbuild/pkg/api"
-	"go.jetpack.io/tyson/msgerror"
+	"go.jetify.com/tyson/msgerror"
 )
 
 type Options struct {

--- a/tyson/testscripts/testscripts_test.go
+++ b/tyson/testscripts/testscripts_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/rogpeppe/go-internal/testscript"
-	"go.jetpack.io/tyson/cmd/tyson/cli"
+	"go.jetify.com/tyson/cmd/tyson/cli"
 )
 
 func TestScripts(t *testing.T) {

--- a/tyson/tyson.go
+++ b/tyson/tyson.go
@@ -1,7 +1,7 @@
 package tyson
 
 import (
-	"go.jetpack.io/tyson/api"
+	"go.jetify.com/tyson/api"
 )
 
 // Eval evaluates a tson file and returns the result as a JSON-encoded byte slice.


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0).
By creating this pull request I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 license.

## Summary
Migrate to go.jetify.com in the opensource repo. As expected, after I merge this in, everything will break ... but I need to check it in first, before I can update all the go.mods.

Plan is as follows:
- [ ] Merge this PR
- [ ] Run go tidy inside opensource
- [ ] Update imports in axiom, and run go tidy
- [ ] Bump major version of any opensource packages we are officially releasing (like typeid). If we're not doing tagged releases, I'm gonna assume people shouldn't be depending directly on HEAD, so I'm ok breaking there.

## How was it tested?
Wasn't. 