### PR TITLE
Clarify license and terms for contributions, reformat markdown

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,7 +3,12 @@
 ## How was it tested?
 
 ## Community Contribution License
-All community contributions in this pull request are licensed to the project maintainers
-under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0).
+
+All community contributions in this pull request are licensed to the project
+maintainers under the terms of the
+[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).
+
 By creating this pull request I represent that I have the right to license the
-contributions to the project maintainers under the Apache 2 license.
+contributions to the project maintainers under the Apache 2 License as stated in
+the
+[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -59,8 +59,8 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement. Use the
-"Report to repository admins" functionality on GitHub to report.
+reported to the community leaders responsible for enforcement. Use the "Report
+to repository admins" functionality on GitHub to report.
 
 All complaints will be reviewed and investigated promptly and fairly.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,19 +1,33 @@
 # Contributing
 
-When contributing to this repository, please describe the change you wish to make via a related issue, or a pull request.
+When contributing to this repository, please describe the change you wish to
+make via a related issue, or a pull request.
 
-Please note we have a [code of conduct](CODE_OF_CONDUCT.md), please follow it in all your interactions with the project.
+Please note we have a [code of conduct](CODE_OF_CONDUCT.md), please follow it in
+all your interactions with the project.
 
-## Developer Certificate of Origin
+## Community Contribution License
 
-By contributing to this project you agree to the [Developer Certificate of Origin](https://developercertificate.org/) (DCO) which was created by the Linux Foundation and is a simple statement that you, as a contributor, have the legal right to make the contribution. See the DCO description for details below:
+Contributions made to this project must be made under the terms of the
+[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).
 
-> By making a contribution to this project, I certify that:
->
-> a. The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or
->
-> b. The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or
->
-> c. The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.
->
-> d. I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
+```
+By making a contribution to this project, you certify that:
+
+  a. The contribution was created in whole or in part by you and you have the right
+  to submit it under the Apache 2 License; or
+
+  b. The contribution is based upon previous work that, to the best of your
+  knowledge, is covered under an appropriate open source license and you have the
+  right under that license to submit that work with modifications, whether
+  created in whole or in part by you, under the Apache 2 License; or
+
+  c. The contribution was provided directly to you by some other person who
+  certified (a), (b) or (c) and you have not modified it.
+
+  d. You understand and agree that this project and the contribution are public
+  and that a record of the contribution (including all personal information you
+  submit with it, including your sign-off) is maintained indefinitely and may be
+  redistributed consistent with this project or the open source license(s)
+  involved.
+```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Open Source Monorepo
 
-Monorepo that serves as the source of truth for all open source projects published
-by [jetify](https://www.jetify.com).
+Monorepo that serves as the source of truth for all open source projects
+published by [jetify](https://www.jetify.com).
 
 Each project lives in its own directory and contains its own license.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Open Source Monorepo
 
-Monorepo that serves as the source of truth for all open source projects
+Monorepo that serves as the source of truth for all open-source projects
 published by [jetify](https://www.jetify.com).
 
 Each project lives in its own directory and contains its own license.

--- a/typeid/typeid-go/CONTRIBUTING.md
+++ b/typeid/typeid-go/CONTRIBUTING.md
@@ -1,25 +1,19 @@
 # Contributing
 
-When contributing to this repository, please describe the change you wish to make via a related issue, or a pull request.
+When contributing to this repository, please describe the change you wish to
+make via a related issue, or a pull request.
 
-Please note we have a [code of conduct](CODE_OF_CONDUCT.md), please follow it in all your interactions with the project.
+Please note we have a [code of conduct](CODE_OF_CONDUCT.md), please follow it in
+all your interactions with the project.
 
 ## Opening a Pull Request
 
-This project is published as a standalone repo from our [opensource monorepo](https://github.com/jetify-com/opensource).
-Pull requests should be sent to the monorepo instead, and they will automatically be published
+This project is published as a standalone repo from our
+[opensource monorepo](https://github.com/jetify-com/opensource). Pull requests
+should be sent to the monorepo instead, and they will automatically be published
 to this repo when merged.
 
-## Developer Certificate of Origin
-
-By contributing to this project you agree to the [Developer Certificate of Origin](https://developercertificate.org/) (DCO) which was created by the Linux Foundation and is a simple statement that you, as a contributor, have the legal right to make the contribution. See the DCO description for details below:
-
-> By making a contribution to this project, I certify that:
->
-> a. The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or
->
-> b. The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or
->
-> c. The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.
->
-> d. I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
+Contributions made to this project must be made under the terms of the
+[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).
+By contributing to this project you agree to the terms stated in the
+[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).

--- a/typeid/typeid-js/CONTRIBUTING.md
+++ b/typeid/typeid-js/CONTRIBUTING.md
@@ -1,25 +1,19 @@
 # Contributing
 
-When contributing to this repository, please describe the change you wish to make via a related issue, or a pull request.
+When contributing to this repository, please describe the change you wish to
+make via a related issue, or a pull request.
 
-Please note we have a [code of conduct](CODE_OF_CONDUCT.md), please follow it in all your interactions with the project.
+Please note we have a [code of conduct](CODE_OF_CONDUCT.md), please follow it in
+all your interactions with the project.
 
 ## Opening a Pull Request
 
-This project is published as a standalone repo from our [opensource monorepo](https://github.com/jetify-com/opensource).
-Pull requests should be sent to the monorepo instead, and they will automatically be published
+This project is published as a standalone repo from our
+[opensource monorepo](https://github.com/jetify-com/opensource). Pull requests
+should be sent to the monorepo instead, and they will automatically be published
 to this repo when merged.
 
-## Developer Certificate of Origin
-
-By contributing to this project you agree to the [Developer Certificate of Origin](https://developercertificate.org/) (DCO) which was created by the Linux Foundation and is a simple statement that you, as a contributor, have the legal right to make the contribution. See the DCO description for details below:
-
-> By making a contribution to this project, I certify that:
->
-> a. The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or
->
-> b. The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or
->
-> c. The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.
->
-> d. I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
+Contributions made to this project must be made under the terms of the
+[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).
+By contributing to this project you agree to the terms stated in the
+[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).

--- a/typeid/typeid-sql/CONTRIBUTING.md
+++ b/typeid/typeid-sql/CONTRIBUTING.md
@@ -1,25 +1,19 @@
 # Contributing
 
-When contributing to this repository, please describe the change you wish to make via a related issue, or a pull request.
+When contributing to this repository, please describe the change you wish to
+make via a related issue, or a pull request.
 
-Please note we have a [code of conduct](CODE_OF_CONDUCT.md), please follow it in all your interactions with the project.
+Please note we have a [code of conduct](CODE_OF_CONDUCT.md), please follow it in
+all your interactions with the project.
 
 ## Opening a Pull Request
 
-This project is published as a standalone repo from our [opensource monorepo](https://github.com/jetify-com/opensource).
-Pull requests should be sent to the monorepo instead, and they will automatically be published
+This project is published as a standalone repo from our
+[opensource monorepo](https://github.com/jetify-com/opensource). Pull requests
+should be sent to the monorepo instead, and they will automatically be published
 to this repo when merged.
 
-## Developer Certificate of Origin
-
-By contributing to this project you agree to the [Developer Certificate of Origin](https://developercertificate.org/) (DCO) which was created by the Linux Foundation and is a simple statement that you, as a contributor, have the legal right to make the contribution. See the DCO description for details below:
-
-> By making a contribution to this project, I certify that:
->
-> a. The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or
->
-> b. The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or
->
-> c. The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.
->
-> d. I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
+Contributions made to this project must be made under the terms of the
+[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).
+By contributing to this project you agree to the terms stated in the
+[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).

--- a/typeid/typeid/CONTRIBUTING.md
+++ b/typeid/typeid/CONTRIBUTING.md
@@ -1,25 +1,19 @@
 # Contributing
 
-When contributing to this repository, please describe the change you wish to make via a related issue, or a pull request.
+When contributing to this repository, please describe the change you wish to
+make via a related issue, or a pull request.
 
-Please note we have a [code of conduct](CODE_OF_CONDUCT.md), please follow it in all your interactions with the project.
+Please note we have a [code of conduct](CODE_OF_CONDUCT.md), please follow it in
+all your interactions with the project.
 
 ## Opening a Pull Request
 
-This project is published as a standalone repo from our [opensource monorepo](https://github.com/jetify-com/opensource).
-Pull requests should be sent to the monorepo instead, and they will automatically be published
+This project is published as a standalone repo from our
+[opensource monorepo](https://github.com/jetify-com/opensource). Pull requests
+should be sent to the monorepo instead, and they will automatically be published
 to this repo when merged.
 
-## Developer Certificate of Origin
-
-By contributing to this project you agree to the [Developer Certificate of Origin](https://developercertificate.org/) (DCO) which was created by the Linux Foundation and is a simple statement that you, as a contributor, have the legal right to make the contribution. See the DCO description for details below:
-
-> By making a contribution to this project, I certify that:
->
-> a. The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or
->
-> b. The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or
->
-> c. The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.
->
-> d. I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
+Contributions made to this project must be made under the terms of the
+[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).
+By contributing to this project you agree to the terms stated in the
+[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).

--- a/tyson/CONTRIBUTING.md
+++ b/tyson/CONTRIBUTING.md
@@ -1,25 +1,19 @@
 # Contributing
 
-When contributing to this repository, please describe the change you wish to make via a related issue, or a pull request.
+When contributing to this repository, please describe the change you wish to
+make via a related issue, or a pull request.
 
-Please note we have a [code of conduct](CODE_OF_CONDUCT.md), please follow it in all your interactions with the project.
+Please note we have a [code of conduct](CODE_OF_CONDUCT.md), please follow it in
+all your interactions with the project.
 
 ## Opening a Pull Request
 
-This project is published as a standalone repo from our [opensource monorepo](https://github.com/jetify-com/opensource).
-Pull requests should be sent to the monorepo instead, and they will automatically be published
+This project is published as a standalone repo from our
+[opensource monorepo](https://github.com/jetify-com/opensource). Pull requests
+should be sent to the monorepo instead, and they will automatically be published
 to this repo when merged.
 
-## Developer Certificate of Origin
-
-By contributing to this project you agree to the [Developer Certificate of Origin](https://developercertificate.org/) (DCO) which was created by the Linux Foundation and is a simple statement that you, as a contributor, have the legal right to make the contribution. See the DCO description for details below:
-
-> By making a contribution to this project, I certify that:
->
-> a. The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or
->
-> b. The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or
->
-> c. The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.
->
-> d. I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
+Contributions made to this project must be made under the terms of the
+[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).
+By contributing to this project you agree to the terms stated in the
+[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).


### PR DESCRIPTION
## Summary
Tweaks several of our files to more clearly explain under what terms we accept contributions.
Reformat markdown files to fit under an 80 character width.

## How was it tested?
N/A

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0).
By creating this pull request I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Refined contribution guidelines by replacing legacy certification language with updated Apache 2 License and Community Contribution License terms.
  - Enhanced readability and consistency across documentation by adjusting formatting, capitalization, and layout in contribution guidelines, code of conduct, and project descriptions.
  - Improved presentation of reporting instructions and introductory content for clearer communication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->