### PR TITLE
Rename package `result` to `try`

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,11 +4,6 @@
 
 ## Community Contribution License
 
-All community contributions in this pull request are licensed to the project
-maintainers under the terms of the
-[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).
+All community contributions in this pull request are licensed to the project maintainers under the terms of the [Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).
 
-By creating this pull request I represent that I have the right to license the
-contributions to the project maintainers under the Apache 2 License as stated in
-the
-[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).
+By creating this pull request I represent that I have the right to license the contributions to the project maintainers under the Apache 2 License as stated in the [Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).

--- a/pkg/try/doc.go
+++ b/pkg/try/doc.go
@@ -1,7 +1,7 @@
-// Package result provides a generic Result type for handling operations that
+// Package try provides a generic Try type for handling operations that
 // can either succeed with a value or fail with an error.
 //
-// The Result type is particularly useful when you want to:
+// The Try type is particularly useful when you want to:
 //   - Defer error handling
 //   - Chain operations that might fail
 //   - Handle both synchronous and asynchronous operations that can fail
@@ -11,12 +11,12 @@
 // Basic usage:
 //
 //	// Create successful results
-//	r1 := result.Ok(42)
-//	r2 := result.From(someFunction()) // from (value, error) pair
+//	r1 := try.Ok(42)
+//	r2 := try.Wrap(someFunction()) // from (value, error) pair
 //
 //	// Create error results
-//	r3 := result.Err[int](errors.New("something went wrong"))
-//	r4 := result.Errf[int]("failed: %v", err)
+//	r3 := try.Err[int](errors.New("something went wrong"))
+//	r4 := try.Errf[int]("failed: %v", err)
 //
 //	// Check result state
 //	if r1.IsOk() {
@@ -25,7 +25,7 @@
 //	}
 //
 //	// Safe error handling
-//	if value, err := r1.Get(); err != nil {
+//	if value, err := r1.Unwrap(); err != nil {
 //	    // handle error...
 //	} else {
 //	    // use value...
@@ -38,15 +38,15 @@
 // operations:
 //
 //	// Convert panics to Results
-//	r := result.Do(func() int {
+//	r := try.Do(func() int {
 //	    // this will be caught if it panics
 //	    return riskyOperation()
 //	})
 //
 //	// Handle async operations
-//	ch := result.Go(func() (int, error) {
+//	ch := try.Go(func() (int, error) {
 //	    // async operation
 //	    return complexCalculation()
 //	})
-//	r := <-ch // receive Result when ready
+//	r := <-ch // receive Try when ready
 package try

--- a/pkg/try/doc.go
+++ b/pkg/try/doc.go
@@ -49,4 +49,4 @@
 //	    return complexCalculation()
 //	})
 //	r := <-ch // receive Result when ready
-package result
+package try

--- a/pkg/try/example_test.go
+++ b/pkg/try/example_test.go
@@ -1,0 +1,152 @@
+package try_test
+
+import (
+	"errors"
+	"fmt"
+
+	"go.jetify.com/pkg/try"
+)
+
+// This example shows how to create successful Try values
+func ExampleOk() {
+	// Create a successful result
+	r := try.Ok(42)
+	fmt.Println("Is ok:", r.IsOk())
+	fmt.Println("Value:", r.MustGet())
+	// Output:
+	// Is ok: true
+	// Value: 42
+}
+
+// This example shows how to wrap a value-error pair into a Try
+func ExampleWrap() {
+	// Function that returns a value and an error
+	someFunction := func() (int, error) {
+		return 42, nil
+	}
+
+	// Wrap the result
+	r := try.Wrap(someFunction())
+	fmt.Println("Is ok:", r.IsOk())
+	fmt.Println("Value:", r.MustGet())
+	// Output:
+	// Is ok: true
+	// Value: 42
+}
+
+// This example shows how to create error results
+func ExampleErr() {
+	// Create error results
+	r1 := try.Err[int](errors.New("something went wrong"))
+	r2 := try.Errf[int]("failed: %v", "bad input")
+
+	fmt.Println("r1 is ok:", r1.IsOk())
+	fmt.Println("r1 error:", r1.Err())
+	fmt.Println("r2 is ok:", r2.IsOk())
+	fmt.Println("r2 error:", r2.Err())
+	// Output:
+	// r1 is ok: false
+	// r1 error: something went wrong
+	// r2 is ok: false
+	// r2 error: failed: bad input
+}
+
+// This example shows how to check the result state
+func ExampleTry_IsOk() {
+	r := try.Ok(42)
+
+	if r.IsOk() {
+		value := r.MustGet()
+		fmt.Println("Got value:", value)
+	} else {
+		fmt.Println("Got error:", r.Err())
+	}
+	// Output:
+	// Got value: 42
+}
+
+// This example shows safe error handling with Unwrap
+func ExampleTry_Unwrap() {
+	// Successful result
+	r1 := try.Ok(42)
+	if value, err := r1.Unwrap(); err != nil {
+		fmt.Println("Error:", err)
+	} else {
+		fmt.Println("Value:", value)
+	}
+
+	// Error result
+	r2 := try.Err[int](errors.New("something went wrong"))
+	if value, err := r2.Unwrap(); err != nil {
+		fmt.Println("Error:", err)
+	} else {
+		fmt.Println("Value:", value)
+	}
+	// Output:
+	// Value: 42
+	// Error: something went wrong
+}
+
+// This example shows how to provide fallback values
+func ExampleTry_OrElse() {
+	// Successful result
+	r1 := try.Ok(42)
+	v1 := r1.OrElse(0)
+	fmt.Println("Value with fallback:", v1)
+
+	// Error result
+	r2 := try.Err[int](errors.New("something went wrong"))
+	v2 := r2.OrElse(0)
+	fmt.Println("Value with fallback for error:", v2)
+	// Output:
+	// Value with fallback: 42
+	// Value with fallback for error: 0
+}
+
+// This example shows how to convert panics to Results
+func ExampleDo() {
+	// A function that might panic
+	riskyOperation := func() int {
+		// Uncomment to see panic handling
+		// panic("something went terribly wrong")
+		return 42
+	}
+
+	// Convert potential panic to Try
+	r := try.Do(func() int {
+		return riskyOperation()
+	})
+
+	if r.IsOk() {
+		fmt.Println("Value:", r.MustGet())
+	} else {
+		fmt.Println("Error:", r.Err())
+	}
+	// Output:
+	// Value: 42
+}
+
+// This example shows how to handle async operations
+func ExampleGo() {
+	// Define a function that simulates a complex calculation
+	complexCalculation := func() (int, error) {
+		// Simulate work
+		return 42, nil
+	}
+
+	// Run the calculation asynchronously
+	ch := try.Go(func() (int, error) {
+		return complexCalculation()
+	})
+
+	// Receive the result when ready
+	r := <-ch
+
+	if r.IsOk() {
+		fmt.Println("Async result:", r.MustGet())
+	} else {
+		fmt.Println("Async error:", r.Err())
+	}
+	// Output:
+	// Async result: 42
+}

--- a/pkg/try/marshal.go
+++ b/pkg/try/marshal.go
@@ -1,4 +1,4 @@
-package result
+package try
 
 import (
 	"encoding/json"
@@ -7,25 +7,25 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-type encodedResult[T any] struct {
+type encodedTry[T any] struct {
 	Value T      `json:"value,omitempty" yaml:"value,omitempty" toml:"value,omitempty"`
 	Error string `json:"error,omitempty" yaml:"error,omitempty" toml:"error,omitempty"`
 }
 
 // toEncoding converts a Result to its encoding representation
-func (r Result[T]) toEncoding() encodedResult[T] {
+func (r Try[T]) toEncoding() encodedTry[T] {
 	if r.IsErr() {
-		return encodedResult[T]{
+		return encodedTry[T]{
 			Error: r.err.Error(),
 		}
 	}
-	return encodedResult[T]{
+	return encodedTry[T]{
 		Value: r.value,
 	}
 }
 
 // fromEncoding converts from an encoding representation to a Result
-func fromEncoding[T any](enc encodedResult[T]) Result[T] {
+func fromEncoding[T any](enc encodedTry[T]) Try[T] {
 	if enc.Error != "" {
 		return Err[T](errors.New(enc.Error))
 	}
@@ -37,14 +37,14 @@ func fromEncoding[T any](enc encodedResult[T]) Result[T] {
 
 // MarshalJSON serializes the Result into JSON. For successful results,
 // it produces {"value": ...}; for errors, it produces {"error": "..."}.
-func (r Result[T]) MarshalJSON() ([]byte, error) {
+func (r Try[T]) MarshalJSON() ([]byte, error) {
 	return json.Marshal(r.toEncoding())
 }
 
 // UnmarshalJSON deserializes from JSON into a Result. It expects either
 // {"value": ...} or {"error": "..."}.
-func (r *Result[T]) UnmarshalJSON(data []byte) error {
-	var enc encodedResult[T]
+func (r *Try[T]) UnmarshalJSON(data []byte) error {
+	var enc encodedTry[T]
 	if err := json.Unmarshal(data, &enc); err != nil {
 		return err
 	}
@@ -56,13 +56,13 @@ func (r *Result[T]) UnmarshalJSON(data []byte) error {
 // --------------
 
 // MarshalYAML serializes the Result into YAML.
-func (r Result[T]) MarshalYAML() (any, error) {
+func (r Try[T]) MarshalYAML() (any, error) {
 	return r.toEncoding(), nil
 }
 
 // UnmarshalYAML deserializes from YAML into a Result.
-func (r *Result[T]) UnmarshalYAML(value *yaml.Node) error {
-	var enc encodedResult[T]
+func (r *Try[T]) UnmarshalYAML(value *yaml.Node) error {
+	var enc encodedTry[T]
 	if err := value.Decode(&enc); err != nil {
 		return err
 	}

--- a/pkg/try/marshal.go
+++ b/pkg/try/marshal.go
@@ -12,7 +12,7 @@ type encodedTry[T any] struct {
 	Error string `json:"error,omitempty" yaml:"error,omitempty" toml:"error,omitempty"`
 }
 
-// toEncoding converts a Result to its encoding representation
+// toEncoding converts a Try to its encoding representation
 func (r Try[T]) toEncoding() encodedTry[T] {
 	if r.IsErr() {
 		return encodedTry[T]{
@@ -24,7 +24,7 @@ func (r Try[T]) toEncoding() encodedTry[T] {
 	}
 }
 
-// fromEncoding converts from an encoding representation to a Result
+// fromEncoding converts from an encoding representation to a Try
 func fromEncoding[T any](enc encodedTry[T]) Try[T] {
 	if enc.Error != "" {
 		return Err[T](errors.New(enc.Error))
@@ -35,13 +35,13 @@ func fromEncoding[T any](enc encodedTry[T]) Try[T] {
 // JSON Marshaling
 // --------------
 
-// MarshalJSON serializes the Result into JSON. For successful results,
+// MarshalJSON serializes the Try into JSON. For successful results,
 // it produces {"value": ...}; for errors, it produces {"error": "..."}.
 func (r Try[T]) MarshalJSON() ([]byte, error) {
 	return json.Marshal(r.toEncoding())
 }
 
-// UnmarshalJSON deserializes from JSON into a Result. It expects either
+// UnmarshalJSON deserializes from JSON into a Try. It expects either
 // {"value": ...} or {"error": "..."}.
 func (r *Try[T]) UnmarshalJSON(data []byte) error {
 	var enc encodedTry[T]
@@ -55,12 +55,12 @@ func (r *Try[T]) UnmarshalJSON(data []byte) error {
 // YAML Marshaling
 // --------------
 
-// MarshalYAML serializes the Result into YAML.
+// MarshalYAML serializes the Try into YAML.
 func (r Try[T]) MarshalYAML() (any, error) {
 	return r.toEncoding(), nil
 }
 
-// UnmarshalYAML deserializes from YAML into a Result.
+// UnmarshalYAML deserializes from YAML into a Try.
 func (r *Try[T]) UnmarshalYAML(value *yaml.Node) error {
 	var enc encodedTry[T]
 	if err := value.Decode(&enc); err != nil {

--- a/pkg/try/marshal_test.go
+++ b/pkg/try/marshal_test.go
@@ -1,4 +1,4 @@
-package result
+package try
 
 import (
 	"encoding/json"
@@ -18,7 +18,7 @@ type encoder interface {
 func TestMarshaling(t *testing.T) {
 	tests := []struct {
 		name     string
-		input    Result[string]
+		input    Try[string]
 		expected map[string]string // expected output for each encoder
 	}{
 		{
@@ -53,7 +53,7 @@ func TestMarshaling(t *testing.T) {
 				assert.Equal(t, test.expected[encName], string(data))
 
 				// Test unmarshaling
-				var actual Result[string]
+				var actual Try[string]
 				err = enc.Unmarshal([]byte(test.expected[encName]), &actual)
 				assert.NoError(t, err)
 
@@ -76,7 +76,7 @@ func TestMarshaling(t *testing.T) {
 
 	for encName, enc := range encoders {
 		t.Run("invalid_"+encName, func(t *testing.T) {
-			var actual Result[string]
+			var actual Try[string]
 			err := enc.Unmarshal([]byte(invalidTests[encName]), &actual)
 			assert.Error(t, err)
 		})
@@ -114,7 +114,7 @@ func TestComplexTypeMarshaling(t *testing.T) {
 			data, err := enc.Marshal(input)
 			assert.NoError(t, err)
 
-			var actual Result[Complex]
+			var actual Try[Complex]
 			err = enc.Unmarshal(data, &actual)
 			assert.NoError(t, err)
 			assert.Equal(t, input.value, actual.value)
@@ -131,7 +131,7 @@ func TestStructRoundtrip(t *testing.T) {
 
 	tests := []struct {
 		name  string
-		input Result[Person]
+		input Try[Person]
 	}{
 		{
 			name: "success case",
@@ -160,7 +160,7 @@ func TestStructRoundtrip(t *testing.T) {
 				require.NoError(t, err)
 
 				// Unmarshal back into a new value
-				var result Result[Person]
+				var result Try[Person]
 				err = enc.Unmarshal(data, &result)
 				require.NoError(t, err)
 

--- a/pkg/try/try.go
+++ b/pkg/try/try.go
@@ -1,4 +1,4 @@
-package result
+package try
 
 import (
 	"errors"
@@ -6,7 +6,7 @@ import (
 )
 
 // Result is a type that can hold either a Value (T) or an error.
-type Result[T any] struct {
+type Try[T any] struct {
 	value T
 	err   error
 }
@@ -15,22 +15,22 @@ type Result[T any] struct {
 // ------------
 
 // Ok returns a Result containing the provided Value.
-func Ok[T any](value T) Result[T] {
-	return Result[T]{value: value}
+func Ok[T any](value T) Try[T] {
+	return Try[T]{value: value}
 }
 
 // Err returns a Result containing the provided error.
-func Err[T any](err error) Result[T] {
-	return Result[T]{err: err}
+func Err[T any](err error) Try[T] {
+	return Try[T]{err: err}
 }
 
 // Errf returns a Result containing a formatted error.
-func Errf[T any](format string, args ...interface{}) Result[T] {
+func Errf[T any](format string, args ...interface{}) Try[T] {
 	return Err[T](fmt.Errorf(format, args...))
 }
 
 // From converts a (Value, error) pair into a Result.
-func From[T any](value T, err error) Result[T] {
+func From[T any](value T, err error) Try[T] {
 	if err != nil {
 		return Err[T](err)
 	}
@@ -41,12 +41,12 @@ func From[T any](value T, err error) Result[T] {
 // ----------
 
 // IsOk reports whether the Result holds a valid Value (Err == nil).
-func (r Result[T]) IsOk() bool {
+func (r Try[T]) IsOk() bool {
 	return r.err == nil
 }
 
 // IsErr reports whether the Result holds an error (Err != nil).
-func (r Result[T]) IsErr() bool {
+func (r Try[T]) IsErr() bool {
 	return r.err != nil
 }
 
@@ -55,19 +55,19 @@ func (r Result[T]) IsErr() bool {
 
 // Unwrap returns the underlying error, if any. This is
 // useful for integrating with Go 1.13+ error wrapping.
-func (r Result[T]) Err() error {
+func (r Try[T]) Err() error {
 	return r.err
 }
 
 // Get returns (Value, error). If r.IsErr(), Value will be
 // the zero Value for T.
-func (r Result[T]) Get() (T, error) {
+func (r Try[T]) Get() (T, error) {
 	return r.value, r.err
 }
 
 // MustGet returns the Value if r.IsOk(), otherwise it panics.
 // Use with caution in production code.
-func (r Result[T]) MustGet() T {
+func (r Try[T]) MustGet() T {
 	if r.err != nil {
 		panic(r.err)
 	}
@@ -75,7 +75,7 @@ func (r Result[T]) MustGet() T {
 }
 
 // OrElse returns the stored Value if IsOk(), or else returns fallback.
-func (r Result[T]) OrElse(fallback T) T {
+func (r Try[T]) OrElse(fallback T) T {
 	if r.err != nil {
 		return fallback
 	}
@@ -86,7 +86,7 @@ func (r Result[T]) OrElse(fallback T) T {
 // --
 
 // String provides a textual representation for debugging/logging.
-func (r Result[T]) String() string {
+func (r Try[T]) String() string {
 	if r.IsOk() {
 		return fmt.Sprintf("Ok(%v)", r.value)
 	}
@@ -94,7 +94,7 @@ func (r Result[T]) String() string {
 }
 
 // GoString provides a Go-syntax representation (used in fmt %#v, etc.).
-func (r Result[T]) GoString() string {
+func (r Try[T]) GoString() string {
 	if r.IsOk() {
 		return fmt.Sprintf("Ok[%T](%#v)", r.value, r.value)
 	}
@@ -108,7 +108,7 @@ func (r Result[T]) GoString() string {
 // If the function panics, the panic is caught and converted to an error Result.
 // For panics that are already errors, they are used directly.
 // For other panic values, they are converted to error strings.
-func Do[T any](fn func() T) (result Result[T]) {
+func Do[T any](fn func() T) (result Try[T]) {
 	defer func() {
 		if r := recover(); r != nil {
 			if err, ok := r.(error); ok {
@@ -124,8 +124,8 @@ func Do[T any](fn func() T) (result Result[T]) {
 // Go runs a function asynchronously and returns a channel of its Result.
 // The function is expected to return a Value and an error.
 // The channel is closed after the function completes and its result is sent.
-func Go[T any](f func() (T, error)) chan Result[T] {
-	out := make(chan Result[T])
+func Go[T any](f func() (T, error)) chan Try[T] {
+	out := make(chan Try[T])
 	go func() {
 		defer close(out)
 		out <- From(f())

--- a/pkg/try/try_test.go
+++ b/pkg/try/try_test.go
@@ -1,4 +1,4 @@
-package result
+package try
 
 import (
 	"errors"

--- a/pkg/try/try_test.go
+++ b/pkg/try/try_test.go
@@ -32,12 +32,12 @@ func TestConstructors(t *testing.T) {
 		assert.EqualError(t, r.Err(), "error 42")
 	})
 
-	t.Run("From", func(t *testing.T) {
-		r1 := From(42, nil)
+	t.Run("Wrap", func(t *testing.T) {
+		r1 := Wrap(42, nil)
 		assert.True(t, r1.IsOk())
 
 		err := errors.New("test error")
-		r2 := From(42, err)
+		r2 := Wrap(42, err)
 		assert.True(t, r2.IsErr())
 	})
 }
@@ -55,18 +55,27 @@ func TestPredicates(t *testing.T) {
 }
 
 func TestMethods(t *testing.T) {
-	t.Run("Get", func(t *testing.T) {
-		v, err := Ok(42).Get()
+	t.Run("Unwrap", func(t *testing.T) {
+		v, err := Ok(42).Unwrap()
 		assert.NoError(t, err)
 		assert.Equal(t, 42, v)
 
 		testErr := errors.New("test")
-		v, err = Err[int](testErr).Get()
+		v, err = Err[int](testErr).Unwrap()
 		// We don't want to use the errorlint rule here because we want to test
-		// that Get returns the exact error we set.
+		// that Unwrap returns the exact error we set.
 		//nolint:errorlint
 		assert.Equal(t, testErr, err)
 		assert.Zero(t, v)
+	})
+
+	t.Run("Get", func(t *testing.T) {
+		v := Ok(42).Get()
+		assert.Equal(t, 42, v)
+
+		// Get should return zero value when Try contains an error
+		z := Err[int](errors.New("test")).Get()
+		assert.Zero(t, z)
 	})
 
 	t.Run("MustGet", func(t *testing.T) {


### PR DESCRIPTION
## Summary
After using `result.Result` for a bit to handle wrapping values and errors, I feel like the name `Result` is too generic and often collides with what the user of the package might be doing. I ran into an example where people were calling this type of wrapper `Try[T]`, and I liked it. This PR renames `Result` to `Try`. I tweaked the names of a few functions as well.

## How was it tested?
Ran the tests.

Once this is checked in, I will update axiom to use the latest naming.

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).
