### PR TITLE
Add ReplayServer

### DIFF
--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -27,6 +27,7 @@ require (
 	go.jetify.com/typeid v1.3.0
 	golang.org/x/oauth2 v0.28.0
 	google.golang.org/protobuf v1.36.5
+	gopkg.in/dnaeon/go-vcr.v4 v4.0.2
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -51,11 +52,7 @@ require (
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/ulikunitz/xz v0.5.12 // indirect
-	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
-	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
-	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
 	golang.org/x/crypto v0.36.0 // indirect
 	golang.org/x/net v0.37.0 // indirect
 	golang.org/x/sys v0.31.0 // indirect
-	gopkg.in/dnaeon/go-vcr.v4 v4.0.2 // indirect
 )

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -51,7 +51,11 @@ require (
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/ulikunitz/xz v0.5.12 // indirect
+	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
+	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
+	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
 	golang.org/x/crypto v0.36.0 // indirect
 	golang.org/x/net v0.37.0 // indirect
 	golang.org/x/sys v0.31.0 // indirect
+	gopkg.in/dnaeon/go-vcr.v4 v4.0.2 // indirect
 )

--- a/pkg/go.sum
+++ b/pkg/go.sum
@@ -86,6 +86,7 @@ github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wx
 github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
 github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
@@ -93,6 +94,12 @@ github.com/tailscale/hujson v0.0.0-20250226034555-ec1d1c113d33 h1:idh63uw+gsG05H
 github.com/tailscale/hujson v0.0.0-20250226034555-ec1d1c113d33/go.mod h1:EbW0wDK/qEUYI0A5bqq0C2kF8JTQwWONmGDBbzsxxHo=
 github.com/ulikunitz/xz v0.5.12 h1:37Nm15o69RwBkXM0J6A5OlE67RZTfzUxTj8fB3dfcsc=
 github.com/ulikunitz/xz v0.5.12/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
+github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=
+github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
+github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=
+github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
+github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17UxZ74=
+github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 go.jetify.com/typeid v1.3.0 h1:fuWV7oxO4mSsgpxwhaVpFXgt0IfjogR29p+XAjDCVKY=
 go.jetify.com/typeid v1.3.0/go.mod h1:CtVGyt2+TSp4Rq5+ARLvGsJqdNypKBAC6INQ9TLPlmk=
@@ -151,6 +158,8 @@ google.golang.org/protobuf v1.36.5/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojt
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
+gopkg.in/dnaeon/go-vcr.v4 v4.0.2 h1:7T5VYf2ifyK01ETHbJPl5A6XTpUljD4Trw3GEDcdedk=
+gopkg.in/dnaeon/go-vcr.v4 v4.0.2/go.mod h1:65yxh9goQVrudqofKtHA4JNFWd6XZRkWfKN4YpMx7KI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/go.sum
+++ b/pkg/go.sum
@@ -86,7 +86,6 @@ github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wx
 github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
 github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
@@ -94,12 +93,6 @@ github.com/tailscale/hujson v0.0.0-20250226034555-ec1d1c113d33 h1:idh63uw+gsG05H
 github.com/tailscale/hujson v0.0.0-20250226034555-ec1d1c113d33/go.mod h1:EbW0wDK/qEUYI0A5bqq0C2kF8JTQwWONmGDBbzsxxHo=
 github.com/ulikunitz/xz v0.5.12 h1:37Nm15o69RwBkXM0J6A5OlE67RZTfzUxTj8fB3dfcsc=
 github.com/ulikunitz/xz v0.5.12/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
-github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=
-github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
-github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=
-github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
-github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17UxZ74=
-github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 go.jetify.com/typeid v1.3.0 h1:fuWV7oxO4mSsgpxwhaVpFXgt0IfjogR29p+XAjDCVKY=
 go.jetify.com/typeid v1.3.0/go.mod h1:CtVGyt2+TSp4Rq5+ARLvGsJqdNypKBAC6INQ9TLPlmk=

--- a/pkg/httpmock/matcher.go
+++ b/pkg/httpmock/matcher.go
@@ -1,0 +1,190 @@
+package httpmock
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/dnaeon/go-vcr.v4/pkg/cassette"
+)
+
+func requireCassetteRequest(tester T, expected cassette.Request, actual *http.Request) bool {
+	tester.Helper()
+
+	// Check each component of the request
+	return checkBasicProperties(tester, expected, actual) &&
+		checkHeaders(tester, expected.Headers, actual.Header) &&
+		checkBody(tester, expected.Body, actual) &&
+		checkFormData(tester, expected.Form, actual) &&
+		checkMetadata(tester, expected, actual) &&
+		checkTrailers(tester, expected.Trailer, actual.Trailer)
+}
+
+// checkBasicProperties validates the basic HTTP request properties like method, URL, and protocol
+func checkBasicProperties(tester T, expected cassette.Request, actual *http.Request) bool {
+	return assert.Condition(tester, func() bool {
+		if expected.Method != "" {
+			if !assert.Equal(tester, expected.Method, actual.Method, "method mismatch") {
+				return false
+			}
+		}
+		if expected.URL != "" {
+			if !assert.Equal(tester, expected.URL, actual.URL.String(), "URL mismatch") {
+				return false
+			}
+		}
+		if expected.Proto != "" {
+			if !assert.Equal(tester, expected.Proto, actual.Proto, "protocol mismatch") {
+				return false
+			}
+		}
+		if expected.ProtoMajor != 0 {
+			if !assert.Equal(tester, expected.ProtoMajor, actual.ProtoMajor, "protocol major version mismatch") {
+				return false
+			}
+		}
+		if expected.ProtoMinor != 0 {
+			if !assert.Equal(tester, expected.ProtoMinor, actual.ProtoMinor, "protocol minor version mismatch") {
+				return false
+			}
+		}
+		return true
+	})
+}
+
+// checkHeaders validates the HTTP headers match the expected values
+func checkHeaders(tester T, expected http.Header, actual http.Header) bool {
+	filteredActual := make(http.Header)
+	for k, v := range actual {
+		filteredActual[http.CanonicalHeaderKey(k)] = v
+	}
+	for _, header := range ignoredHeaders {
+		filteredActual.Del(header)
+	}
+
+	return assert.Condition(tester, func() bool {
+		for k, v := range expected {
+			canonicalKey := http.CanonicalHeaderKey(k)
+			actualValues := filteredActual[canonicalKey]
+			if !assert.NotEmpty(tester, actualValues, "missing header %q", k) {
+				return false
+			}
+			if !assert.ElementsMatch(tester, v, actualValues, "header %q values mismatch", k) {
+				return false
+			}
+		}
+		return true
+	})
+}
+
+// checkBody validates the request body matches the expected value
+func checkBody(tester T, expected string, actual *http.Request) bool {
+	if expected == "" {
+		return true
+	}
+
+	if !assert.NotNil(tester, actual.Body, "missing request body") {
+		return false
+	}
+
+	bodyBytes, err := io.ReadAll(actual.Body)
+	if !assert.NoError(tester, err, "error reading request body") {
+		return false
+	}
+	actual.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+
+	// Try JSON comparison first
+	if isJSON(expected) && isJSON(string(bodyBytes)) {
+		return assert.JSONEq(tester, expected, string(bodyBytes), "JSON body mismatch")
+	}
+
+	return assert.Equal(tester, expected, string(bodyBytes), "body mismatch")
+}
+
+// isJSON checks if a string is valid JSON
+func isJSON(str string) bool {
+	var js interface{}
+	return str != "" && str[0] == '{' && json.Unmarshal([]byte(str), &js) == nil
+}
+
+// checkFormData validates the form data matches the expected values
+func checkFormData(tester T, expected map[string][]string, actual *http.Request) bool {
+	if len(expected) == 0 {
+		return true
+	}
+
+	if !assert.NoError(tester, actual.ParseForm(), "error parsing form data") {
+		return false
+	}
+
+	return assert.Condition(tester, func() bool {
+		for k, expectedValues := range expected {
+			actualValues := actual.Form[k]
+			if !assert.NotEmpty(tester, actualValues, "missing form field %q", k) {
+				return false
+			}
+			if !assert.ElementsMatch(tester, expectedValues, actualValues, "form field %q values mismatch", k) {
+				return false
+			}
+		}
+		return true
+	})
+}
+
+// checkMetadata validates request metadata like content length and transfer encoding
+func checkMetadata(tester T, expected cassette.Request, actual *http.Request) bool {
+	return assert.Condition(tester, func() bool {
+		if expected.ContentLength != 0 {
+			if !assert.Equal(tester, expected.ContentLength, actual.ContentLength, "content length mismatch") {
+				return false
+			}
+		}
+		if len(expected.TransferEncoding) > 0 {
+			if !assert.ElementsMatch(tester, expected.TransferEncoding, actual.TransferEncoding, "transfer encoding mismatch") {
+				return false
+			}
+		}
+		if expected.Host != "" {
+			if !assert.Equal(tester, expected.Host, actual.Host, "host mismatch") {
+				return false
+			}
+		}
+		if expected.RequestURI != "" {
+			if !assert.Equal(tester, expected.RequestURI, actual.RequestURI, "request URI mismatch") {
+				return false
+			}
+		}
+		return true
+	})
+}
+
+// checkTrailers validates the trailer headers match the expected values
+func checkTrailers(tester T, expected http.Header, actual http.Header) bool {
+	if len(expected) == 0 {
+		return true
+	}
+
+	filteredTrailer := make(http.Header)
+	for k, v := range actual {
+		filteredTrailer[http.CanonicalHeaderKey(k)] = v
+	}
+	for _, header := range ignoredHeaders {
+		filteredTrailer.Del(header)
+	}
+
+	return assert.Condition(tester, func() bool {
+		for k, v := range expected {
+			canonicalKey := http.CanonicalHeaderKey(k)
+			actualValues := filteredTrailer[canonicalKey]
+			if !assert.NotEmpty(tester, actualValues, "missing trailer header %q", k) {
+				return false
+			}
+			if !assert.ElementsMatch(tester, v, actualValues, "trailer header %q values mismatch", k) {
+				return false
+			}
+		}
+		return true
+	})
+}

--- a/pkg/httpmock/matcher.go
+++ b/pkg/httpmock/matcher.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/dnaeon/go-vcr.v4/pkg/cassette"
@@ -105,8 +106,15 @@ func checkBody(tester T, expected string, actual *http.Request) bool {
 
 // isJSON checks if a string is valid JSON
 func isJSON(str string) bool {
+	if str == "" {
+		return false
+	}
+	str = strings.TrimSpace(str)
+	if str == "" || (str[0] != '{' && str[0] != '[') {
+		return false
+	}
 	var js interface{}
-	return str != "" && str[0] == '{' && json.Unmarshal([]byte(str), &js) == nil
+	return json.Unmarshal([]byte(str), &js) == nil
 }
 
 // checkFormData validates the form data matches the expected values

--- a/pkg/httpmock/matcher_test.go
+++ b/pkg/httpmock/matcher_test.go
@@ -1,0 +1,725 @@
+package httpmock
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/dnaeon/go-vcr.v4/pkg/cassette"
+)
+
+func TestCheckBasicProperties(t *testing.T) {
+	tests := []struct {
+		name        string
+		request     *http.Request
+		cassetteReq cassette.Request
+		wantFail    bool
+	}{
+		{
+			name: "all properties match",
+			request: &http.Request{
+				Method:     http.MethodPost,
+				URL:        mustParseURL("https://api.example.com/test"),
+				Proto:      "HTTP/1.1",
+				ProtoMajor: 1,
+				ProtoMinor: 1,
+			},
+			cassetteReq: cassette.Request{
+				Method:     http.MethodPost,
+				URL:        "https://api.example.com/test",
+				Proto:      "HTTP/1.1",
+				ProtoMajor: 1,
+				ProtoMinor: 1,
+			},
+			wantFail: false,
+		},
+		{
+			name: "method mismatch",
+			request: &http.Request{
+				Method: http.MethodPost,
+				URL:    mustParseURL("https://api.example.com/test"),
+			},
+			cassetteReq: cassette.Request{
+				Method: http.MethodGet,
+				URL:    "https://api.example.com/test",
+			},
+			wantFail: true,
+		},
+		{
+			name: "URL mismatch",
+			request: &http.Request{
+				Method: http.MethodPost,
+				URL:    mustParseURL("https://api.example.com/test"),
+			},
+			cassetteReq: cassette.Request{
+				Method: http.MethodPost,
+				URL:    "https://api.example.com/different",
+			},
+			wantFail: true,
+		},
+		{
+			name: "empty cassette fields match anything",
+			request: &http.Request{
+				Method:     http.MethodPost,
+				URL:        mustParseURL("https://api.example.com/test"),
+				Proto:      "HTTP/1.1",
+				ProtoMajor: 1,
+				ProtoMinor: 1,
+			},
+			cassetteReq: cassette.Request{},
+			wantFail:    false,
+		},
+		{
+			name: "proto mismatch",
+			request: &http.Request{
+				Method:     http.MethodPost,
+				URL:        mustParseURL("https://api.example.com/test"),
+				Proto:      "HTTP/1.0",
+				ProtoMajor: 1,
+				ProtoMinor: 0,
+			},
+			cassetteReq: cassette.Request{
+				Method:     http.MethodPost,
+				URL:        "https://api.example.com/test",
+				Proto:      "HTTP/1.1",
+				ProtoMajor: 1,
+				ProtoMinor: 1,
+			},
+			wantFail: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockTester := &mockT{}
+			got := checkBasicProperties(mockTester, tt.cassetteReq, tt.request)
+			assert.Equal(t, !tt.wantFail, got)
+			assert.Equal(t, tt.wantFail, mockTester.failed)
+		})
+	}
+}
+
+func TestCheckHeaders(t *testing.T) {
+	tests := []struct {
+		name     string
+		actual   http.Header
+		expected http.Header
+		wantFail bool
+	}{
+		{
+			name: "exact match",
+			actual: http.Header{
+				"Content-Type": []string{"application/json"},
+				"Accept":       []string{"*/*"},
+			},
+			expected: http.Header{
+				"Content-Type": []string{"application/json"},
+			},
+			wantFail: false,
+		},
+		{
+			name: "header value mismatch",
+			actual: http.Header{
+				"Content-Type": []string{"application/xml"},
+			},
+			expected: http.Header{
+				"Content-Type": []string{"application/json"},
+			},
+			wantFail: true,
+		},
+		{
+			name: "missing expected header",
+			actual: http.Header{
+				"Accept": []string{"*/*"},
+			},
+			expected: http.Header{
+				"Content-Type": []string{"application/json"},
+			},
+			wantFail: true,
+		},
+		{
+			name: "ignores extra headers in actual",
+			actual: http.Header{
+				"Content-Type": []string{"application/json"},
+				"Extra":        []string{"value"},
+			},
+			expected: http.Header{
+				"Content-Type": []string{"application/json"},
+			},
+			wantFail: false,
+		},
+		{
+			name: "ignores case in header names",
+			actual: http.Header{
+				"content-type": []string{"application/json"},
+			},
+			expected: http.Header{
+				"Content-Type": []string{"application/json"},
+			},
+			wantFail: false,
+		},
+		{
+			name:     "empty expected headers match anything",
+			actual:   http.Header{"Content-Type": []string{"application/json"}},
+			expected: http.Header{},
+			wantFail: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockTester := &mockT{}
+			got := checkHeaders(mockTester, tt.expected, tt.actual)
+			assert.Equal(t, !tt.wantFail, got)
+			assert.Equal(t, tt.wantFail, mockTester.failed)
+		})
+	}
+}
+
+func TestCheckBody(t *testing.T) {
+	tests := []struct {
+		name        string
+		request     *http.Request
+		cassetteReq cassette.Request
+		wantFail    bool
+	}{
+		{
+			name: "exact JSON match",
+			request: &http.Request{
+				Body: makeBody(`{"key": "value", "number": 42}`),
+			},
+			cassetteReq: cassette.Request{
+				Body: `{"key": "value", "number": 42}`,
+			},
+			wantFail: false,
+		},
+		{
+			name: "JSON field order doesn't matter",
+			request: &http.Request{
+				Body: makeBody(`{"number": 42, "key": "value"}`),
+			},
+			cassetteReq: cassette.Request{
+				Body: `{"key": "value", "number": 42}`,
+			},
+			wantFail: false,
+		},
+		{
+			name: "non-JSON exact match",
+			request: &http.Request{
+				Body: makeBody("plain text body"),
+			},
+			cassetteReq: cassette.Request{
+				Body: "plain text body",
+			},
+			wantFail: false,
+		},
+		{
+			name: "non-JSON mismatch",
+			request: &http.Request{
+				Body: makeBody("different text"),
+			},
+			cassetteReq: cassette.Request{
+				Body: "plain text body",
+			},
+			wantFail: true,
+		},
+		{
+			name: "empty cassette body matches anything",
+			request: &http.Request{
+				Body: makeBody("any content"),
+			},
+			cassetteReq: cassette.Request{
+				Body: "",
+			},
+			wantFail: false,
+		},
+		{
+			name: "nil request body only matches empty cassette body",
+			request: &http.Request{
+				Body: nil,
+			},
+			cassetteReq: cassette.Request{
+				Body: "expected content",
+			},
+			wantFail: true,
+		},
+		{
+			name: "error reading body",
+			request: &http.Request{
+				Body: errorReader{},
+			},
+			cassetteReq: cassette.Request{
+				Body: "expected content",
+			},
+			wantFail: true,
+		},
+		{
+			name: "invalid JSON in request when cassette has valid JSON",
+			request: &http.Request{
+				Body: makeBody(`invalid json`),
+			},
+			cassetteReq: cassette.Request{
+				Body: `{"key": "value"}`,
+			},
+			wantFail: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockTester := &mockT{}
+			got := checkBody(mockTester, tt.cassetteReq.Body, tt.request)
+			assert.Equal(t, !tt.wantFail, got)
+			assert.Equal(t, tt.wantFail, mockTester.failed)
+		})
+	}
+}
+
+func TestCheckFormData(t *testing.T) {
+	tests := []struct {
+		name        string
+		request     *http.Request
+		cassetteReq cassette.Request
+		wantFail    bool
+	}{
+		{
+			name: "exact form match",
+			request: func() *http.Request {
+				form := url.Values{}
+				form.Add("key1", "value1")
+				form.Add("key2", "value2")
+				req := &http.Request{
+					Method: http.MethodPost,
+					URL:    mustParseURL("https://example.com"),
+					Header: http.Header{
+						"Content-Type": []string{"application/x-www-form-urlencoded"},
+					},
+					Body: makeBody(form.Encode()),
+				}
+				if err := req.ParseForm(); err != nil {
+					panic(err)
+				}
+				return req
+			}(),
+			cassetteReq: cassette.Request{
+				Form: url.Values{
+					"key1": []string{"value1"},
+					"key2": []string{"value2"},
+				},
+			},
+			wantFail: false,
+		},
+		{
+			name: "form value mismatch",
+			request: func() *http.Request {
+				form := url.Values{}
+				form.Add("key1", "wrong")
+				req := &http.Request{
+					Method: http.MethodPost,
+					URL:    mustParseURL("https://example.com"),
+					Header: http.Header{
+						"Content-Type": []string{"application/x-www-form-urlencoded"},
+					},
+					Body: makeBody(form.Encode()),
+				}
+				if err := req.ParseForm(); err != nil {
+					panic(err)
+				}
+				return req
+			}(),
+			cassetteReq: cassette.Request{
+				Form: url.Values{
+					"key1": []string{"value1"},
+				},
+			},
+			wantFail: true,
+		},
+		{
+			name: "missing form field",
+			request: func() *http.Request {
+				form := url.Values{}
+				form.Add("key1", "value1")
+				req := &http.Request{
+					Method: http.MethodPost,
+					URL:    mustParseURL("https://example.com"),
+					Header: http.Header{
+						"Content-Type": []string{"application/x-www-form-urlencoded"},
+					},
+					Body: makeBody(form.Encode()),
+				}
+				if err := req.ParseForm(); err != nil {
+					panic(err)
+				}
+				return req
+			}(),
+			cassetteReq: cassette.Request{
+				Form: url.Values{
+					"key1": []string{"value1"},
+					"key2": []string{"value2"},
+				},
+			},
+			wantFail: true,
+		},
+		{
+			name: "empty cassette form matches anything",
+			request: func() *http.Request {
+				form := url.Values{}
+				form.Add("key1", "value1")
+				req := &http.Request{
+					Method: http.MethodPost,
+					URL:    mustParseURL("https://example.com"),
+					Header: http.Header{
+						"Content-Type": []string{"application/x-www-form-urlencoded"},
+					},
+					Body: makeBody(form.Encode()),
+				}
+				if err := req.ParseForm(); err != nil {
+					panic(err)
+				}
+				return req
+			}(),
+			cassetteReq: cassette.Request{
+				Form: url.Values{},
+			},
+			wantFail: false,
+		},
+		{
+			name: "parse form error",
+			request: &http.Request{
+				Method: http.MethodPost,
+				URL:    mustParseURL("https://example.com"),
+				Header: http.Header{
+					"Content-Type": []string{"application/x-www-form-urlencoded"},
+				},
+				Body: makeBody("%invalid%form%data%"),
+			},
+			cassetteReq: cassette.Request{
+				Form: url.Values{
+					"key1": []string{"value1"},
+				},
+			},
+			wantFail: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockTester := &mockT{}
+			got := checkFormData(mockTester, tt.cassetteReq.Form, tt.request)
+			assert.Equal(t, !tt.wantFail, got)
+			assert.Equal(t, tt.wantFail, mockTester.failed)
+		})
+	}
+}
+
+func TestCheckMetadata(t *testing.T) {
+	tests := []struct {
+		name        string
+		request     *http.Request
+		cassetteReq cassette.Request
+		wantFail    bool
+	}{
+		{
+			name: "all properties match",
+			request: &http.Request{
+				ContentLength:    100,
+				TransferEncoding: []string{"chunked"},
+				Host:             "example.com",
+				RemoteAddr:       "192.168.1.1:1234",
+				RequestURI:       "/test?key=value",
+			},
+			cassetteReq: cassette.Request{
+				ContentLength:    100,
+				TransferEncoding: []string{"chunked"},
+				Host:             "example.com",
+				RemoteAddr:       "192.168.1.1:1234",
+				RequestURI:       "/test?key=value",
+			},
+			wantFail: false,
+		},
+		{
+			name: "content length mismatch",
+			request: &http.Request{
+				ContentLength: 100,
+			},
+			cassetteReq: cassette.Request{
+				ContentLength: 200,
+			},
+			wantFail: true,
+		},
+		{
+			name: "transfer encoding mismatch",
+			request: &http.Request{
+				TransferEncoding: []string{"chunked"},
+			},
+			cassetteReq: cassette.Request{
+				TransferEncoding: []string{"gzip"},
+			},
+			wantFail: true,
+		},
+		{
+			name: "host mismatch",
+			request: &http.Request{
+				Host: "example.com",
+			},
+			cassetteReq: cassette.Request{
+				Host: "different.com",
+			},
+			wantFail: true,
+		},
+		{
+			name: "empty cassette properties match anything",
+			request: &http.Request{
+				ContentLength:    100,
+				TransferEncoding: []string{"chunked"},
+				Host:             "example.com",
+				RemoteAddr:       "192.168.1.1:1234",
+				RequestURI:       "/test?key=value",
+			},
+			cassetteReq: cassette.Request{},
+			wantFail:    false,
+		},
+		{
+			name: "transfer encoding order mismatch",
+			request: &http.Request{
+				TransferEncoding: []string{"chunked", "gzip"},
+			},
+			cassetteReq: cassette.Request{
+				TransferEncoding: []string{"gzip", "chunked"},
+			},
+			wantFail: false,
+		},
+		{
+			name: "request uri mismatch",
+			request: &http.Request{
+				RequestURI: "/api/v1/users",
+			},
+			cassetteReq: cassette.Request{
+				RequestURI: "/api/v2/users",
+			},
+			wantFail: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockTester := &mockT{}
+			got := checkMetadata(mockTester, tt.cassetteReq, tt.request)
+			assert.Equal(t, !tt.wantFail, got)
+			assert.Equal(t, tt.wantFail, mockTester.failed)
+		})
+	}
+}
+
+func TestCheckTrailers(t *testing.T) {
+	tests := []struct {
+		name        string
+		request     *http.Request
+		cassetteReq cassette.Request
+		wantFail    bool
+	}{
+		{
+			name: "exact trailer match",
+			request: &http.Request{
+				Trailer: http.Header{
+					"X-Trailer": []string{"value"},
+				},
+			},
+			cassetteReq: cassette.Request{
+				Trailer: http.Header{
+					"X-Trailer": []string{"value"},
+				},
+			},
+			wantFail: false,
+		},
+		{
+			name: "trailer value mismatch",
+			request: &http.Request{
+				Trailer: http.Header{
+					"X-Trailer": []string{"value1"},
+				},
+			},
+			cassetteReq: cassette.Request{
+				Trailer: http.Header{
+					"X-Trailer": []string{"value2"},
+				},
+			},
+			wantFail: true,
+		},
+		{
+			name: "missing trailer",
+			request: &http.Request{
+				Trailer: http.Header{},
+			},
+			cassetteReq: cassette.Request{
+				Trailer: http.Header{
+					"X-Trailer": []string{"value"},
+				},
+			},
+			wantFail: true,
+		},
+		{
+			name: "empty cassette trailers match anything",
+			request: &http.Request{
+				Trailer: http.Header{
+					"X-Trailer": []string{"value"},
+				},
+			},
+			cassetteReq: cassette.Request{
+				Trailer: http.Header{},
+			},
+			wantFail: false,
+		},
+		{
+			name: "trailer header mismatch",
+			request: &http.Request{
+				Trailer: http.Header{
+					"X-Trailer": []string{"value1"},
+					"X-Other":   []string{"other"},
+				},
+			},
+			cassetteReq: cassette.Request{
+				Trailer: http.Header{
+					"X-Trailer": []string{"value2"},
+				},
+			},
+			wantFail: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockTester := &mockT{}
+			got := checkTrailers(mockTester, tt.cassetteReq.Trailer, tt.request.Trailer)
+			assert.Equal(t, !tt.wantFail, got)
+			assert.Equal(t, tt.wantFail, mockTester.failed)
+		})
+	}
+}
+
+func TestRequireCassetteRequest(t *testing.T) {
+	tests := []struct {
+		name        string
+		request     *http.Request
+		cassetteReq cassette.Request
+		wantFail    bool
+	}{
+		{
+			name: "complete match",
+			request: &http.Request{
+				Method:     http.MethodPost,
+				URL:        mustParseURL("https://api.example.com/test"),
+				Proto:      "HTTP/1.1",
+				ProtoMajor: 1,
+				ProtoMinor: 1,
+				Header: http.Header{
+					"Content-Type": []string{"application/json"},
+					"X-Custom":     []string{"value"},
+				},
+				Body:             makeBody(`{"key":"value"}`),
+				ContentLength:    16,
+				Host:             "api.example.com",
+				TransferEncoding: []string{"chunked"},
+				Trailer: http.Header{
+					"X-Trailer": []string{"value"},
+				},
+			},
+			cassetteReq: cassette.Request{
+				Method:     http.MethodPost,
+				URL:        "https://api.example.com/test",
+				Proto:      "HTTP/1.1",
+				ProtoMajor: 1,
+				ProtoMinor: 1,
+				Headers: http.Header{
+					"Content-Type": []string{"application/json"},
+				},
+				Body:             `{"key":"value"}`,
+				ContentLength:    16,
+				Host:             "api.example.com",
+				TransferEncoding: []string{"chunked"},
+				Trailer: http.Header{
+					"X-Trailer": []string{"value"},
+				},
+			},
+			wantFail: false,
+		},
+		{
+			name: "partial match with minimal cassette",
+			request: &http.Request{
+				Method: http.MethodPost,
+				URL:    mustParseURL("https://api.example.com/test"),
+				Header: http.Header{
+					"Content-Type": []string{"application/json"},
+					"X-Custom":     []string{"value"},
+				},
+				Body: makeBody(`{"key":"value"}`),
+			},
+			cassetteReq: cassette.Request{
+				Method: http.MethodPost,
+				URL:    "https://api.example.com/test",
+				Headers: http.Header{
+					"Content-Type": []string{"application/json"},
+				},
+			},
+			wantFail: false,
+		},
+		{
+			name: "mismatch in one property fails entire match",
+			request: &http.Request{
+				Method: http.MethodPost,
+				URL:    mustParseURL("https://api.example.com/test"),
+				Header: http.Header{
+					"Content-Type": []string{"application/json"},
+				},
+				Body: makeBody(`{"key":"value"}`),
+			},
+			cassetteReq: cassette.Request{
+				Method: http.MethodGet,
+				URL:    "https://api.example.com/test",
+				Headers: http.Header{
+					"Content-Type": []string{"application/json"},
+				},
+				Body: `{"key":"value"}`,
+			},
+			wantFail: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockTester := &mockT{}
+			got := requireCassetteRequest(mockTester, tt.cassetteReq, tt.request)
+			assert.Equal(t, !tt.wantFail, got)
+			assert.Equal(t, tt.wantFail, mockTester.failed)
+		})
+	}
+}
+
+// Helper functions
+
+func mustParseURL(s string) *url.URL {
+	u, err := url.Parse(s)
+	if err != nil {
+		panic(err)
+	}
+	return u
+}
+
+func makeBody(s string) io.ReadCloser {
+	return io.NopCloser(strings.NewReader(s))
+}
+
+// Helper type for testing read errors
+type errorReader struct{}
+
+func (errorReader) Read(p []byte) (n int, err error) {
+	return 0, fmt.Errorf("simulated read error")
+}
+
+func (errorReader) Close() error {
+	return nil
+}

--- a/pkg/httpmock/replay.go
+++ b/pkg/httpmock/replay.go
@@ -1,0 +1,165 @@
+package httpmock
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/dnaeon/go-vcr.v4/pkg/cassette"
+	"gopkg.in/dnaeon/go-vcr.v4/pkg/recorder"
+)
+
+type ReplayServer struct {
+	server  *httptest.Server
+	rec     *recorder.Recorder
+	t       T
+	realURL *url.URL
+}
+
+type ReplayConfig struct {
+	Host     string
+	Cassette string
+}
+
+func NewReplayServer(tester T, config ReplayConfig) (*ReplayServer, error) {
+	tester.Helper()
+
+	// Parse and validate the real endpoint we'll proxy to in record mode
+	realURL, err := url.Parse(config.Host)
+	if err != nil {
+		return nil, fmt.Errorf("invalid Host: %v", err)
+	}
+	if realURL.Scheme == "" || realURL.Host == "" {
+		return nil, fmt.Errorf("invalid Host: URL must have scheme and host")
+	}
+
+	// Create ReplayServer first
+	replayServer := &ReplayServer{realURL: realURL, t: tester}
+
+	rec, err := recorder.New(
+		config.Cassette,
+		recorder.WithMode(recorder.ModeRecordOnce),
+		recorder.WithHook(removeIgnored, recorder.AfterCaptureHook),
+		recorder.WithMatcher(func(request *http.Request, cassetteRequest cassette.Request) bool {
+			return requireCassetteRequest(tester, cassetteRequest, request)
+		}),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create recorder: %v", err)
+	}
+
+	replayServer.rec = rec
+	replayServer.server = httptest.NewServer(http.HandlerFunc(replayServer.handler))
+
+	return replayServer, nil
+}
+
+// handler processes incoming requests by either replaying them from the cassette
+// or proxying them to the real endpoint and recording the result.
+func (rs *ReplayServer) handler(w http.ResponseWriter, req *http.Request) {
+	// Create a copy of the request for matching
+	matchReq := *req
+
+	// We'll rewrite the request's scheme and host to point at the real endpoint
+	matchReq.URL.Scheme = rs.realURL.Scheme
+	matchReq.URL.Host = rs.realURL.Host
+	matchReq.Host = rs.realURL.Host
+
+	// Now let the recorder handle it (replay or forward+record)
+	resp, roundTripErr := rs.rec.RoundTrip(&matchReq)
+	if roundTripErr != nil {
+		// Log the error details for debugging
+		rs.t.Errorf("Replay server error: %v", roundTripErr)
+		// Enhance error reporting for request matching failures
+		http.Error(w, fmt.Sprintf("request did not match cassette: %v", roundTripErr), http.StatusInternalServerError)
+		return
+	}
+	defer resp.Body.Close()
+
+	// Copy response status, headers, body
+	for k, vals := range resp.Header {
+		for _, val := range vals {
+			w.Header().Add(k, val)
+		}
+	}
+	w.WriteHeader(resp.StatusCode)
+	if _, copyErr := io.Copy(w, resp.Body); copyErr != nil {
+		rs.t.Errorf("Error copying response body: %v", copyErr)
+		http.Error(w, fmt.Sprintf("error copying response: %v", copyErr), http.StatusInternalServerError)
+		require.NoError(rs.t, copyErr)
+	}
+}
+
+// formatRequestBody reads and returns the request body as a string, restoring it afterward
+func formatRequestBody(req *http.Request) string {
+	if req.Body == nil {
+		return ""
+	}
+
+	bodyBytes, err := io.ReadAll(req.Body)
+	if err != nil {
+		return fmt.Sprintf("error reading body: %v", err)
+	}
+	// Restore the body for later use
+	req.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+
+	return string(bodyBytes)
+}
+
+func (rs *ReplayServer) Close() error {
+	// Stop the HTTP server first
+	rs.server.Close()
+
+	// Then stop the recorder to finalize writing (if in record mode)
+	return rs.rec.Stop()
+}
+
+// URL returns the base URL of the replay server.
+func (rs *ReplayServer) URL() string {
+	return rs.server.URL
+}
+
+var ignoredHeaders = []string{
+	// Sensitive headers:
+	"Authorization",
+	"Proxy-Authorization",
+	"WWW-Authenticate",
+	"Proxy-Authenticate",
+	"Cookie",
+	"Set-Cookie",
+	"X-API-Key",
+	"X-Auth-Token",
+	"X-CSRF-Token",
+	"X-Requested-With",
+	"X-Forwarded-For",
+	"X-Real-IP",
+	"X-Client-IP",
+
+	// Other headers:
+	"User-Agent",
+	"Accept",
+	"Accept-Encoding",
+	"Accept-Language",
+	"Connection",
+	"Content-Length",
+}
+
+// removeIgnored is a recorder hook that removes ignored headers and request fields
+// before they are saved to the cassette.
+func removeIgnored(i *cassette.Interaction) error {
+	// Remove request headers
+	for _, header := range ignoredHeaders {
+		i.Request.Headers.Del(header)
+	}
+	// Remove response headers
+	for _, header := range ignoredHeaders {
+		i.Response.Headers.Del(header)
+	}
+	// Remove remote address from request
+	i.Request.RemoteAddr = ""
+	return nil
+}

--- a/pkg/httpmock/replay.go
+++ b/pkg/httpmock/replay.go
@@ -14,6 +14,14 @@ import (
 	"gopkg.in/dnaeon/go-vcr.v4/pkg/recorder"
 )
 
+// ReplayServer is a server that can be used to test HTTP interactions by
+// recording and replaying real HTTP requests.
+//
+// When a test is first run, the ReplayServer will record the interactions
+// and save them to a "cassette" file.
+//
+// On subsequent runs, the ReplayServer will replay the interactions from the
+// cassette file, allowing for consistent tests.
 type ReplayServer struct {
 	server           *httptest.Server
 	rec              *recorder.Recorder
@@ -23,11 +31,18 @@ type ReplayServer struct {
 	usedInteractions atomic.Int32
 }
 
+// ReplayConfig is the configuration for a ReplayServer.
 type ReplayConfig struct {
-	Host     string
+	// Host is the address of the real endpoints we're proxying requests to,
+	// e.g. "https://api.example.com".
+	Host string
+	// Cassette is the name of the cassette file to use for recording and replaying.
+	// If the cassette does not exist, it will be created.
+	// Do not include the ".yaml" extension, it will be added automatically.
 	Cassette string
 }
 
+// NewReplayServer creates a new ReplayServer.
 func NewReplayServer(tester T, config ReplayConfig) (*ReplayServer, error) {
 	tester.Helper()
 
@@ -120,6 +135,8 @@ func formatRequestBody(req *http.Request) string {
 	return string(bodyBytes)
 }
 
+// Close stops the ReplayServer and verifies that all recorded interactions
+// were used.
 func (rs *ReplayServer) Close() error {
 	// Stop the HTTP server first
 	rs.server.Close()

--- a/pkg/httpmock/replay_test.go
+++ b/pkg/httpmock/replay_test.go
@@ -1,0 +1,366 @@
+package httpmock
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/dnaeon/go-vcr.v4/pkg/cassette"
+)
+
+func TestNewReplayServer(t *testing.T) {
+	tests := []struct {
+		name        string
+		config      ReplayConfig
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name: "valid configuration",
+			config: ReplayConfig{
+				Host:     "https://jsonplaceholder.typicode.com",
+				Cassette: filepath.Join("testdata", "valid"),
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid host URL",
+			config: ReplayConfig{
+				Host:     "://invalid-url",
+				Cassette: filepath.Join("testdata", "invalid"),
+			},
+			wantErr:     true,
+			errContains: "invalid Host",
+		},
+		{
+			name: "empty host",
+			config: ReplayConfig{
+				Host:     "",
+				Cassette: filepath.Join("testdata", "empty"),
+			},
+			wantErr:     true,
+			errContains: "invalid Host",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			replayServer, err := NewReplayServer(t, test.config)
+			if test.wantErr {
+				assert.Error(t, err)
+				if test.errContains != "" {
+					assert.Contains(t, err.Error(), test.errContains)
+				}
+				assert.Nil(t, replayServer)
+				return
+			}
+			require.NotNil(t, replayServer, "replay server should not be nil")
+			assert.Equal(t, test.config.Host, replayServer.realURL.String())
+
+			// Test cleanup
+			err = replayServer.Close()
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestReplayServerHandler(t *testing.T) {
+	tests := []struct {
+		name           string
+		request        Request
+		expectedStatus int
+		expectedBody   string
+	}{
+		{
+			name: "successful_get",
+			request: Request{
+				Method: http.MethodGet,
+				Path:   "/get",
+				Headers: map[string]string{
+					"Host": "httpbin.org",
+				},
+			},
+			expectedStatus: http.StatusOK,
+			expectedBody:   `"url": "https://httpbin.org/get"`,
+		},
+		{
+			name: "post_with_body",
+			request: Request{
+				Method: http.MethodPost,
+				Path:   "/post",
+				Headers: map[string]string{
+					"Host":         "httpbin.org",
+					"Content-Type": "application/json",
+				},
+				Body: `{"test": "data"}`,
+			},
+			expectedStatus: http.StatusOK,
+			expectedBody:   `"test": "data"`,
+		},
+		{
+			name: "get_with_header",
+			request: Request{
+				Method: http.MethodGet,
+				Path:   "/headers",
+				Headers: map[string]string{
+					"Host":          "httpbin.org",
+					"X-Test-Header": "test-value",
+				},
+			},
+			expectedStatus: http.StatusOK,
+			expectedBody:   `"X-Test-Header": "test-value"`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Create a mock T that will record failures
+			mockTester := &mockT{}
+
+			// Create a server with a normal request and response
+			server, err := NewReplayServer(mockTester, ReplayConfig{
+				Host:     "https://httpbin.org",
+				Cassette: "testdata/" + test.name,
+			})
+			require.NoError(t, err)
+			defer server.Close()
+
+			// Build the request using the declarative Request struct
+			req, err := buildRequest(server.URL(), test.request)
+			require.NoError(t, err)
+
+			// Make the request
+			resp, err := http.DefaultClient.Do(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			// Check response status
+			assert.Equal(t, test.expectedStatus, resp.StatusCode)
+
+			// Check response body
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+			assert.Contains(t, string(body), test.expectedBody)
+
+			// Close the server to ensure the cassette is saved
+			err = server.Close()
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestFormatRequestBody(t *testing.T) {
+	tests := []struct {
+		name     string
+		body     io.ReadCloser
+		expected string
+	}{
+		{
+			name:     "nil body",
+			body:     nil,
+			expected: "",
+		},
+		{
+			name:     "empty body",
+			body:     io.NopCloser(bytes.NewReader([]byte{})),
+			expected: "",
+		},
+		{
+			name:     "string body",
+			body:     io.NopCloser(bytes.NewReader([]byte("test body"))),
+			expected: "test body",
+		},
+		{
+			name:     "json body",
+			body:     io.NopCloser(bytes.NewReader([]byte(`{"key":"value"}`))),
+			expected: `{"key":"value"}`,
+		},
+		{
+			name:     "error reading body",
+			body:     errorReader{},
+			expected: "error reading body: simulated read error",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req := &http.Request{
+				Body: test.body,
+			}
+			result := formatRequestBody(req)
+			assert.Equal(t, test.expected, result)
+
+			// If the body was readable, verify it can still be read
+			if test.body != nil && test.name != "error reading body" {
+				body, err := io.ReadAll(req.Body)
+				require.NoError(t, err)
+				assert.Equal(t, test.expected, string(body), "body should be readable after formatting")
+			}
+		})
+	}
+}
+
+func TestRemoveIgnored(t *testing.T) {
+	tests := []struct {
+		name        string
+		interaction *cassette.Interaction
+		wantHeaders http.Header
+	}{
+		{
+			name: "removes all ignored headers",
+			interaction: &cassette.Interaction{
+				Request: cassette.Request{
+					Headers: http.Header{
+						"Authorization":       []string{"Bearer token"},
+						"Content-Type":        []string{"application/json"},
+						"User-Agent":          []string{"test-agent"},
+						"X-Custom":            []string{"value"},
+						"Accept":              []string{"*/*"},
+						"Cookie":              []string{"session=123"},
+						"X-Forwarded-For":     []string{"1.2.3.4"},
+						"X-Api-Key":           []string{"secret"},
+						"X-Csrf-Token":        []string{"token"},
+						"X-Requested-With":    []string{"XMLHttpRequest"},
+						"X-Real-Ip":           []string{"1.2.3.4"},
+						"X-Client-Ip":         []string{"1.2.3.4"},
+						"Proxy-Authorization": []string{"Basic auth"},
+						"Www-Authenticate":    []string{"Basic"},
+						"Proxy-Authenticate":  []string{"Basic"},
+						"Set-Cookie":          []string{"session=456"},
+					},
+				},
+				Response: cassette.Response{
+					Headers: http.Header{
+						"Set-Cookie":   []string{"session=789"},
+						"Content-Type": []string{"application/json"},
+					},
+				},
+			},
+			wantHeaders: http.Header{
+				"Content-Type": {"application/json"},
+				"X-Custom":     {"value"},
+			},
+		},
+		{
+			name: "keeps non-ignored headers",
+			interaction: &cassette.Interaction{
+				Request: cassette.Request{
+					Headers: http.Header{
+						"Content-Type": []string{"application/json"},
+						"X-Custom":     {"value"},
+					},
+				},
+				Response: cassette.Response{
+					Headers: http.Header{
+						"Content-Type": []string{"application/json"},
+						"X-Custom":     {"value"},
+					},
+				},
+			},
+			wantHeaders: http.Header{
+				"Content-Type": {"application/json"},
+				"X-Custom":     {"value"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := removeIgnored(test.interaction)
+			assert.NoError(t, err)
+
+			// Check request headers
+			assert.Equal(t, test.wantHeaders, test.interaction.Request.Headers)
+
+			// Check response headers
+			for _, h := range ignoredHeaders {
+				assert.Empty(t, test.interaction.Response.Headers[h], "ignored header %q should be removed from response", h)
+			}
+		})
+	}
+}
+
+func TestReplayServerFailures(t *testing.T) {
+	tests := []struct {
+		name          string
+		request       Request
+		expectedError bool
+		errorContains string
+	}{
+		{
+			name: "mismatched_method",
+			request: Request{
+				Method: http.MethodPost, // Cassette has GET /get, but we'll send POST
+				Path:   "/get",
+				Headers: map[string]string{
+					"Host": "httpbin.org",
+				},
+			},
+			expectedError: true,
+			errorContains: "method mismatch",
+		},
+		{
+			name: "mismatched_path",
+			request: Request{
+				Method: http.MethodGet,
+				Path:   "/wrong", // Cassette has /get, but we'll send /wrong
+				Headers: map[string]string{
+					"Host": "httpbin.org",
+				},
+			},
+			expectedError: true,
+			errorContains: "URL mismatch",
+		},
+		{
+			name: "mismatched_body",
+			request: Request{
+				Method: http.MethodPost,
+				Path:   "/post",
+				Headers: map[string]string{
+					"Host":         "httpbin.org",
+					"Content-Type": "application/json",
+				},
+				Body: `{"unexpected": "data"}`, // Cassette has empty body, we'll send one
+			},
+			expectedError: true,
+			errorContains: "method mismatch",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Use a mockT to capture failures
+			mockTester := &mockT{}
+
+			// Use the successful_get cassette which has a GET /get request recorded
+			replayServer, err := NewReplayServer(mockTester, ReplayConfig{
+				Host:     "https://httpbin.org",
+				Cassette: filepath.Join("testdata", "successful_get"),
+			})
+			require.NoError(t, err)
+			defer replayServer.Close()
+
+			// Create a response recorder
+			w := httptest.NewRecorder()
+
+			// Build the request using the declarative Request struct
+			req, err := buildRequest(replayServer.URL(), test.request)
+			require.NoError(t, err)
+
+			// Call the handler with the mismatched request
+			replayServer.handler(w, req)
+
+			// Verify the test failed as expected
+			if test.expectedError {
+				assert.Contains(t, mockTester.errors[0], test.errorContains, "expected error message not found")
+			} else {
+				assert.Empty(t, mockTester.errors, "unexpected errors: %v", mockTester.errors)
+			}
+		})
+	}
+}

--- a/pkg/httpmock/replay_test.go
+++ b/pkg/httpmock/replay_test.go
@@ -291,6 +291,7 @@ func TestReplayServerFailures(t *testing.T) {
 		request       Request
 		expectedError bool
 		errorContains string
+		cassette      string
 	}{
 		{
 			name: "mismatched_method",
@@ -303,6 +304,7 @@ func TestReplayServerFailures(t *testing.T) {
 			},
 			expectedError: true,
 			errorContains: "method mismatch",
+			cassette:      "successful_get",
 		},
 		{
 			name: "mismatched_path",
@@ -315,6 +317,7 @@ func TestReplayServerFailures(t *testing.T) {
 			},
 			expectedError: true,
 			errorContains: "URL mismatch",
+			cassette:      "successful_get",
 		},
 		{
 			name: "mismatched_body",
@@ -328,7 +331,8 @@ func TestReplayServerFailures(t *testing.T) {
 				Body: `{"unexpected": "data"}`, // Cassette has empty body, we'll send one
 			},
 			expectedError: true,
-			errorContains: "method mismatch",
+			errorContains: "body mismatch",
+			cassette:      "post_with_body",
 		},
 	}
 
@@ -337,10 +341,10 @@ func TestReplayServerFailures(t *testing.T) {
 			// Use a mockT to capture failures
 			mockTester := &mockT{}
 
-			// Use the successful_get cassette which has a GET /get request recorded
+			// Create a server with a normal request and response
 			replayServer, err := NewReplayServer(mockTester, ReplayConfig{
 				Host:     "https://httpbin.org",
-				Cassette: filepath.Join("testdata", "successful_get"),
+				Cassette: filepath.Join("testdata", test.cassette),
 			})
 			require.NoError(t, err)
 			defer replayServer.Close()

--- a/pkg/httpmock/testdata/get_with_header.yaml
+++ b/pkg/httpmock/testdata/get_with_header.yaml
@@ -1,0 +1,44 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: httpbin.org
+        remote_addr: 192.0.2.1:1234
+        request_uri: /headers
+        body: ""
+        form: {}
+        headers:
+            X-Test-Header:
+                - test-value
+        url: https://httpbin.org/headers
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 226
+        uncompressed: false
+        body: "{\n  \"headers\": {\n    \"Accept-Encoding\": \"gzip\", \n    \"Host\": \"httpbin.org\", \n    \"User-Agent\": \"Go-http-client/2.0\", \n    \"X-Amzn-Trace-Id\": \"Root=1-67eb08c7-5b6e7ce13e71b48c65dd151c\", \n    \"X-Test-Header\": \"test-value\"\n  }\n}\n"
+        headers:
+            Access-Control-Allow-Credentials:
+                - "true"
+            Access-Control-Allow-Origin:
+                - '*'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 31 Mar 2025 21:27:35 GMT
+            Server:
+                - gunicorn/19.9.0
+        status: 200 OK
+        code: 200
+        duration: 658.003166ms

--- a/pkg/httpmock/testdata/multiple_interactions.yaml
+++ b/pkg/httpmock/testdata/multiple_interactions.yaml
@@ -1,0 +1,24 @@
+---
+interactions:
+  - request:
+      method: GET
+      url: https://httpbin.org/get
+      headers:
+        Host: [httpbin.org]
+      body: ""
+    response:
+      status: 200
+      headers:
+        Content-Type: [application/json]
+      body: '{"args":{},"headers":{"Accept-Encoding":"gzip","Host":"httpbin.org","User-Agent":"Go-http-client/1.1"},"url":"https://httpbin.org/get"}'
+  - request:
+      method: GET
+      url: https://httpbin.org/status/200
+      headers:
+        Host: [httpbin.org]
+      body: ""
+    response:
+      status: 200
+      headers:
+        Content-Type: [text/plain]
+      body: "OK"

--- a/pkg/httpmock/testdata/post_with_body.yaml
+++ b/pkg/httpmock/testdata/post_with_body.yaml
@@ -1,0 +1,44 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 16
+        transfer_encoding: []
+        trailer: {}
+        host: httpbin.org
+        remote_addr: 192.0.2.1:1234
+        request_uri: /post
+        body: '{"test": "data"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+        url: https://httpbin.org/post
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 447
+        uncompressed: false
+        body: "{\n  \"args\": {}, \n  \"data\": \"{\\\"test\\\": \\\"data\\\"}\", \n  \"files\": {}, \n  \"form\": {}, \n  \"headers\": {\n    \"Accept-Encoding\": \"gzip\", \n    \"Content-Length\": \"16\", \n    \"Content-Type\": \"application/json\", \n    \"Host\": \"httpbin.org\", \n    \"User-Agent\": \"Go-http-client/2.0\", \n    \"X-Amzn-Trace-Id\": \"Root=1-67eb08c6-7cb6405921cbf8a42127f272\"\n  }, \n  \"json\": {\n    \"test\": \"data\"\n  }, \n  \"origin\": \"173.172.25.129\", \n  \"url\": \"https://httpbin.org/post\"\n}\n"
+        headers:
+            Access-Control-Allow-Credentials:
+                - "true"
+            Access-Control-Allow-Origin:
+                - '*'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 31 Mar 2025 21:27:34 GMT
+            Server:
+                - gunicorn/19.9.0
+        status: 200 OK
+        code: 200
+        duration: 278.381958ms

--- a/pkg/httpmock/testdata/successful_get.yaml
+++ b/pkg/httpmock/testdata/successful_get.yaml
@@ -1,0 +1,42 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: httpbin.org
+        remote_addr: 192.0.2.1:1234
+        request_uri: /get
+        body: ""
+        form: {}
+        headers: {}
+        url: https://httpbin.org/get
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 273
+        uncompressed: false
+        body: "{\n  \"args\": {}, \n  \"headers\": {\n    \"Accept-Encoding\": \"gzip\", \n    \"Host\": \"httpbin.org\", \n    \"User-Agent\": \"Go-http-client/2.0\", \n    \"X-Amzn-Trace-Id\": \"Root=1-67eb08c6-00c116f01402db9429cc7391\"\n  }, \n  \"origin\": \"173.172.25.129\", \n  \"url\": \"https://httpbin.org/get\"\n}\n"
+        headers:
+            Access-Control-Allow-Credentials:
+                - "true"
+            Access-Control-Allow-Origin:
+                - '*'
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 31 Mar 2025 21:27:34 GMT
+            Server:
+                - gunicorn/19.9.0
+        status: 200 OK
+        code: 200
+        duration: 332.85275ms

--- a/pkg/httpmock/testdata/valid.yaml
+++ b/pkg/httpmock/testdata/valid.yaml
@@ -1,0 +1,3 @@
+---
+version: 2
+interactions: []


### PR DESCRIPTION
## Summary
Adds a new type of server to `httpmock`: a ReplayServer. This type of server allows you to talk to a real API when first creating the test and then records the interaction for replay later. 

## How was it tested?
Unit tests.

## Community Contribution License

All community contributions in this pull request are licensed to the project maintainers under the terms of the [Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request I represent that I have the right to license the contributions to the project maintainers under the Apache 2 License as stated in the [Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).
