### PR TITLE
[httpmock] revert invalid-json response change from #462

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Automatically sets up your devbox environment whenever you cd into this
+# directory via our direnv integration:
+
+eval "$(devbox generate direnv --print-envrc)"
+
+# check out https://www.jetpack.io/devbox/docs/ide_configuration/direnv/
+# for more details

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 .DS_Store
 
 dist
+
+.vscode

--- a/pkg/httpmock/httpmock.go
+++ b/pkg/httpmock/httpmock.go
@@ -218,9 +218,6 @@ func writeResponse(w http.ResponseWriter, response Response) error {
 		}
 	}
 	return nil
-
-	// // For non-string bodies, encode as JSON
-	// return json.NewEncoder(w).Encode(response.Body)
 }
 
 // requireBodyEq verifies that the actual body matches the expected body.

--- a/pkg/httpmock/httpmock_test.go
+++ b/pkg/httpmock/httpmock_test.go
@@ -586,7 +586,7 @@ func TestServer_ResponseHeaders(t *testing.T) {
 			response: Response{
 				StatusCode: http.StatusNotFound,
 				Status:     "Not Found",
-				Body:       "Resource not found",
+				Body:       `"Resource not found"`,
 			},
 			wantHeaders: map[string]string{
 				"Content-Type":  "application/json",
@@ -603,6 +603,18 @@ func TestServer_ResponseHeaders(t *testing.T) {
 			wantHeaders: map[string]string{},
 			wantCode:    http.StatusNoContent,
 			wantBody:    "",
+		},
+		{
+			name: "invalid json body in response",
+			response: Response{
+				StatusCode: http.StatusBadRequest,
+				Body:       `"invalid":json}`,
+			},
+			wantHeaders: map[string]string{
+				"Content-Type": "application/json",
+			},
+			wantCode: http.StatusBadRequest,
+			wantBody: `"invalid":json}`,
 		},
 	}
 


### PR DESCRIPTION
## Summary

This PR reverts a part of #462

The code being reverted would make invalid json received be returned as valid json. No need to do that.
It also makes clients (that are using httpmock library) harder to test. We want the client to be 
able to check for invalid json responses.

## How was it tested?

go test -v ./pkg/httpmock/...

Also see:  https://github.com/jetify-com/axiom/pull/5879/files#r2061087920

## Community Contribution License

All community contributions in this pull request are licensed to the project maintainers under the terms of the [Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request I represent that I have the right to license the contributions to the project maintainers under the Apache 2 License as stated in the [Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).
