### PR TITLE
refactor(try): simplify the interface of the Try package. 

### DIFF
--- a/pkg/try/doc.go
+++ b/pkg/try/doc.go
@@ -5,14 +5,13 @@
 //   - Defer error handling
 //   - Chain operations that might fail
 //   - Handle both synchronous and asynchronous operations that can fail
-//   - Convert panics into errors
 //   - Process a list of tasks, each of which might fail
 //
 // Basic usage:
 //
 //	// Create successful results
 //	r1 := try.Ok(42)
-//	r2 := try.Wrap(someFunction()) // from (value, error) pair
+//	r2 := try.From(someFunction()) // from (value, error) pair
 //
 //	// Create error results
 //	r3 := try.Err[int](errors.New("something went wrong"))
@@ -25,28 +24,12 @@
 //	}
 //
 //	// Safe error handling
-//	if value, err := r1.Unwrap(); err != nil {
+//	if value, err := r1.Get(); err != nil {
 //	    // handle error...
 //	} else {
 //	    // use value...
 //	}
 //
 //	// Provide fallback values
-//	value := r1.OrElse(0) // returns 0 if r1 contains an error
-//
-// The package also provides utilities for handling panics and asynchronous
-// operations:
-//
-//	// Convert panics to Results
-//	r := try.Do(func() int {
-//	    // this will be caught if it panics
-//	    return riskyOperation()
-//	})
-//
-//	// Handle async operations
-//	ch := try.Go(func() (int, error) {
-//	    // async operation
-//	    return complexCalculation()
-//	})
-//	r := <-ch // receive Try when ready
+//	value := r1.GetOrElse(0) // returns 0 if r1 contains an error
 package try

--- a/pkg/try/example_test.go
+++ b/pkg/try/example_test.go
@@ -19,14 +19,14 @@ func ExampleOk() {
 }
 
 // This example shows how to wrap a value-error pair into a Try
-func ExampleWrap() {
+func ExampleFrom() {
 	// Function that returns a value and an error
 	someFunction := func() (int, error) {
 		return 42, nil
 	}
 
-	// Wrap the result
-	r := try.Wrap(someFunction())
+	// From the result
+	r := try.From(someFunction())
 	fmt.Println("Is ok:", r.IsOk())
 	fmt.Println("Value:", r.MustGet())
 	// Output:
@@ -65,11 +65,11 @@ func ExampleTry_IsOk() {
 	// Got value: 42
 }
 
-// This example shows safe error handling with Unwrap
-func ExampleTry_Unwrap() {
+// This example shows safe error handling with Get
+func ExampleTry_Get() {
 	// Successful result
 	r1 := try.Ok(42)
-	if value, err := r1.Unwrap(); err != nil {
+	if value, err := r1.Get(); err != nil {
 		fmt.Println("Error:", err)
 	} else {
 		fmt.Println("Value:", value)
@@ -77,7 +77,7 @@ func ExampleTry_Unwrap() {
 
 	// Error result
 	r2 := try.Err[int](errors.New("something went wrong"))
-	if value, err := r2.Unwrap(); err != nil {
+	if value, err := r2.Get(); err != nil {
 		fmt.Println("Error:", err)
 	} else {
 		fmt.Println("Value:", value)
@@ -88,65 +88,17 @@ func ExampleTry_Unwrap() {
 }
 
 // This example shows how to provide fallback values
-func ExampleTry_OrElse() {
+func ExampleTry_GetOrElse() {
 	// Successful result
 	r1 := try.Ok(42)
-	v1 := r1.OrElse(0)
+	v1 := r1.GetOrElse(0)
 	fmt.Println("Value with fallback:", v1)
 
 	// Error result
 	r2 := try.Err[int](errors.New("something went wrong"))
-	v2 := r2.OrElse(0)
+	v2 := r2.GetOrElse(0)
 	fmt.Println("Value with fallback for error:", v2)
 	// Output:
 	// Value with fallback: 42
 	// Value with fallback for error: 0
-}
-
-// This example shows how to convert panics to Results
-func ExampleDo() {
-	// A function that might panic
-	riskyOperation := func() int {
-		// Uncomment to see panic handling
-		// panic("something went terribly wrong")
-		return 42
-	}
-
-	// Convert potential panic to Try
-	r := try.Do(func() int {
-		return riskyOperation()
-	})
-
-	if r.IsOk() {
-		fmt.Println("Value:", r.MustGet())
-	} else {
-		fmt.Println("Error:", r.Err())
-	}
-	// Output:
-	// Value: 42
-}
-
-// This example shows how to handle async operations
-func ExampleGo() {
-	// Define a function that simulates a complex calculation
-	complexCalculation := func() (int, error) {
-		// Simulate work
-		return 42, nil
-	}
-
-	// Run the calculation asynchronously
-	ch := try.Go(func() (int, error) {
-		return complexCalculation()
-	})
-
-	// Receive the result when ready
-	r := <-ch
-
-	if r.IsOk() {
-		fmt.Println("Async result:", r.MustGet())
-	} else {
-		fmt.Println("Async error:", r.Err())
-	}
-	// Output:
-	// Async result: 42
 }


### PR DESCRIPTION
## Summary
- Rename Wrap -> From for better semantic clarity
- Rename Unwrap -> Get to be more idiomatic
- Rename OrElse -> GetOrElse for consistency with other getters
- Remove Do/Go action methods to simplify the API
- Update all tests and documentation to reflect changes

## How was it tested?
Updated unit tests, and they pass. 

## Community Contribution License

All community contributions in this pull request are licensed to the project maintainers under the terms of the [Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request I represent that I have the right to license the contributions to the project maintainers under the Apache 2 License as stated in the [Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).
