### PR TITLE
feat: Add support for scanning Postgres tuples

### DIFF
--- a/typeid/typeid-go/sql.go
+++ b/typeid/typeid-go/sql.go
@@ -3,7 +3,10 @@ package typeid
 import (
 	"database/sql/driver"
 	"fmt"
+	"strings"
 )
+
+const minTupleStringLength = 40 // (x,00000000-0000-0000-0000-000000000000)
 
 // Scan implements the sql.Scanner interface so the TypeIDs can be read from
 // databases transparently. Currently database types that map to string are
@@ -17,10 +20,33 @@ func (tid *TypeID[P]) Scan(src any) error {
 			return nil
 		}
 		return tid.UnmarshalText([]byte(obj))
-	// TODO: add support for []byte
-	// we don't just want to store the full string as a byte array. Instead
-	// we should encode using the UUID bytes. We could add support for
-	// Binary Marshalling and Unmarshalling at the same time.
+	case []byte:
+		if len(obj) == 0 {
+			return nil
+		}
+
+		// typeid-sql can store TypeIDs as tuples of the form (prefix,uuid).
+		if len(obj) < minTupleStringLength || obj[0] != '(' || obj[len(obj)-1] != ')' {
+			// TODO: add support for []byte
+			// we don't just want to store the full string as a byte array. Instead
+			// we should encode using the UUID bytes. We could add support for
+			// Binary Marshalling and Unmarshalling at the same time.
+			return fmt.Errorf("unsupported format for scan type %T", obj)
+		}
+
+		obj = obj[1 : len(obj)-1]
+		parts := strings.Split(string(obj), ",")
+		if len(parts) != 2 {
+			return fmt.Errorf("invalid TypeID format: %s", obj)
+		}
+
+		parsedID, err := fromUUID[TypeID[P]](parts[0], parts[1])
+		if err != nil {
+			return fmt.Errorf("invalid UUID: %s: %w", parts[1], err)
+		}
+
+		*tid = parsedID
+		return nil
 	default:
 		return fmt.Errorf("unsupported scan type %T", obj)
 	}

--- a/typeid/typeid-go/sql_test.go
+++ b/typeid/typeid-go/sql_test.go
@@ -8,18 +8,23 @@ import (
 )
 
 func TestScan(t *testing.T) {
+	t.Parallel()
+
 	testdata := []struct {
 		name     string
 		input    any
 		expected typeid.AnyID
 	}{
-		{"valid", "prefix_00041061050r3gg28a1c60t3gf", typeid.Must(typeid.FromString("prefix_00041061050r3gg28a1c60t3gf"))},
+		{"valid_text", "prefix_01jtvs4hppfp8azhhy9x703dc1", typeid.Must(typeid.FromString("prefix_01jtvs4hppfp8azhhy9x703dc1"))},
+		{"valid_tuple", []byte("(prefix,0196b792-46d6-7d90-afc6-3e4f4e01b581)"), typeid.Must(typeid.FromString("prefix_01jtvs4hppfp8azhhy9x703dc1"))},
 		{"nil", nil, typeid.AnyID{}},
 		{"empty string", "", typeid.AnyID{}},
 	}
 
 	for _, td := range testdata {
 		t.Run(td.name, func(t *testing.T) {
+			t.Parallel()
+
 			var scanned typeid.AnyID
 			err := scanned.Scan(td.input)
 			assert.NoError(t, err)
@@ -31,8 +36,9 @@ func TestScan(t *testing.T) {
 }
 
 func TestValuer(t *testing.T) {
-	expected := "prefix_00041061050r3gg28a1c60t3gf"
-	tid := typeid.Must(typeid.FromString("prefix_00041061050r3gg28a1c60t3gf"))
+	t.Parallel()
+	expected := "prefix_01jtvs4hppfp8azhhy9x703dc1"
+	tid := typeid.Must(typeid.FromString("prefix_01jtvs4hppfp8azhhy9x703dc1"))
 	actual, err := tid.Value()
 	assert.NoError(t, err)
 	assert.Equal(t, expected, actual)


### PR DESCRIPTION
## Summary

When storing TypeIDs in Postgres as [compound types](https://github.com/jetify-com/typeid-sql?tab=readme-ov-file#2-uuid-based-encoding-using-compound-types), Postgres will return a TypeID value for a column in the format `"(prefix,uuid)"`. This change enables the `Scan()` method to detect this format and correctly deserialize it into a TypeID.

## How was it tested?

- Added a unit test to verify the ability to parse this format.

## Community Contribution License

All community contributions in this pull request are licensed to the project maintainers under the terms of the [Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request I represent that I have the right to license the contributions to the project maintainers under the Apache 2 License as stated in the [Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).
