### PR TITLE
Move optional and pointer to opensource, update lint rules

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,13 +1,11 @@
-# TODO(Landau): Turn on all linters
-# TODO(Landau): move this to top level of opensource?
 run:
   go: "1.23"
 linters:
   disable-all: true
   enable:
     - dupl
-    - errorlint
     - errcheck
+    - errorlint
     - gofmt
     - goimports
     - gosimple
@@ -27,14 +25,34 @@ linters:
     - usestdlibvars
     - usetesting
     - varnamelen
-    # If we're going to use github.com/pkg/errors we should probably turn this on?
-    # Let's adopt new stackerr lib and we can turn this on.
     # - wrapcheck
-    - unused
+issues:
+  exclude-files:
+    - ".*\\.connect\\.go$"
+    - ".*\\.pb\\.go$"
+  exclude:
+    # It's usually better to start off _not_ wrapping an error unless it
+    # should be part of your API. Errors should be wrapped only when it's
+    # useful.
+    #
+    # See https://go.dev/blog/go1.13-errors
+    - "non-wrapping format verb for fmt.Errorf"
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - dupl
 
+    # TODO(gcurtis): temporary until this file is used.
+    - path: terminal.*\.go
+      linters:
+        - unused
 linters-settings:
-  errorlint:
-    errorf: false
+  errcheck:
+    exclude-functions:
+      # Dropped/canceled/timed out connections or bad clients make checking this
+      # error pointless 99% of the time.
+      - (net/http.ResponseWriter).Write
+      - (flag/*FlagSet).Parse
   revive:
     rules: # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md
       - name: atomic
@@ -56,15 +74,38 @@ linters-settings:
       - name: var-naming
       - name: unreachable-code
   varnamelen:
-    max-distance: 10
+    max-distance: 40
     ignore-decls:
-      - id []byte
+      - c echo.Context
+      - const C
+      - db database.Db
+      - db db
+      - e error
+      - e watch.Event
+      - f *foo.Bar
+      - i int
+      - id string
+      - id any
+      - m map[string]any
+      - m map[string]int
+      - mc api.CliServiceClient
+      - ns *komponents.Namespace
+      - ns komponents.Namespace
+      - ns string
       - r *http.Request
-      - r io.Reader
+      - T any
       - t testing.T
-      - v any
+      - vc *viewer.MockViewer
+      - vc Context
+      - vc viewer
+      - vc viewer.CommonContext
+      - vc viewer.Context
       - w http.ResponseWriter
       - w io.Writer
-  # TODO: enable this
-  # unparam:
-  #   check-exported: true
+  unconvert:
+    fast-math: true
+  wrapcheck:
+    ignoreSigRegexps:
+      - ".*confkit.*Validate.*"
+    ignorePackageGlobs:
+      - "go.jetify.com/axiom/api/*"

--- a/pkg/optional/doc.go
+++ b/pkg/optional/doc.go
@@ -1,0 +1,63 @@
+// Package optional provides a generic Option[T] type and helpers for representing
+// values that may or may not be present.
+//
+// The Option[T] type is a lightweight, allocation-free abstraction similar to the
+// "Maybe" or "Optional" types found in other languages.  It is useful for
+// expressing that a value might be absent without resorting to pointers or
+// sentinel values.
+//
+// # Basic construction
+//
+// There are two canonical constructors:
+//
+//	opt := optional.Some(42) // value is set
+//	opt := optional.None[int]() // value is not set
+//
+// Accessing values
+//
+//	v, ok := opt.Get()         // returns value and whether it is set
+//	v := opt.GetOrElse(0)      // returns value or a default
+//	v := opt.MustGet()         // panics if value is not set
+//	if opt.IsNone() { ... }    // tests for absence
+//
+// Pointers
+//
+//	opt := optional.Ptr(ptr)   // wraps a *T, set to the value of ptr when ptr != nil
+//
+// # Primitive helpers
+//
+// For convenience the package exposes helper constructors for primitive types:
+//
+//	optional.Int(1)        // Option[int]
+//	optional.Float64(3.14) // Option[float64]
+//	optional.String("hi") // Option[string]
+//
+// These are entirely equivalent to calling Some(value) but sometimes improve
+// readability.
+//
+// # JSON integration
+//
+// Option implements json.Marshaler and json.Unmarshaler.  A None value
+// marshals to JSON null, while Some(value) marshals to the JSON representation
+// of the contained value.
+//
+// When Option fields are used inside structs the 'omitzero' tag can be used to
+// omit None() values entirely:
+//
+//	type Person struct {
+//	    Name string          `json:"name"`
+//	    Age  optional.Option[int] `json:"age,omitzero"` // omitted when None
+//	}
+//
+// # Zero value behavior
+//
+// The zero value of Option[T] is considered "not set" (None).  As a result an
+// Option field in a struct that is left uninitialized will behave as None().
+//
+// # Concurrency
+//
+// Option is a value type. Copies are immutable and safe for concurrent reads.
+// The only mutator is (*Option).UnmarshalJSON; if you share the same Option
+// *pointer* between goroutines, guard that pointer with a mutex while
+// unmarshalling.
+package optional

--- a/pkg/optional/doc.go
+++ b/pkg/optional/doc.go
@@ -53,11 +53,4 @@
 //
 // The zero value of Option[T] is considered "not set" (None).  As a result an
 // Option field in a struct that is left uninitialized will behave as None().
-//
-// # Concurrency
-//
-// Option is a value type. Copies are immutable and safe for concurrent reads.
-// The only mutator is (*Option).UnmarshalJSON; if you share the same Option
-// *pointer* between goroutines, guard that pointer with a mutex while
-// unmarshalling.
 package optional

--- a/pkg/optional/optional.go
+++ b/pkg/optional/optional.go
@@ -1,0 +1,126 @@
+// Package optional provides an Option type for representing values that may or may not be present.
+package optional
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Option represents an optional value of type T
+type Option[T any] struct {
+	value T
+	set   bool
+}
+
+// Some creates an value that is set
+func Some[T any](value T) Option[T] {
+	return Option[T]{
+		value: value,
+		set:   true,
+	}
+}
+
+// None creates an empty value that is not set
+func None[T any]() Option[T] {
+	return Option[T]{
+		set: false,
+	}
+}
+
+// Ptr creates an Option value from a pointer.
+// The value is set if the pointer is not nil, and not set if the pointer is nil.
+//
+// T should not be a pointer type.
+func Ptr[T any](ptr *T) Option[T] {
+	if ptr == nil {
+		return None[T]()
+	}
+	return Some(*ptr)
+}
+
+// Get returns the underlying value and whether it's set
+func (o Option[T]) Get() (T, bool) {
+	return o.value, o.set
+}
+
+// MustGet returns the value or panics if not set
+func (o Option[T]) MustGet() T {
+	if !o.set {
+		panic("option value not set")
+	}
+	return o.value
+}
+
+// GetOrElse returns the contained value or a default if it is not set
+func (o Option[T]) GetOrElse(defaultValue T) T {
+	if !o.set {
+		return defaultValue
+	}
+	return o.value
+}
+
+// IsNone returns true if there is no set value
+func (o Option[T]) IsNone() bool {
+	return !o.set
+}
+
+// String returns a textual representation for debugging/logging
+func (o Option[T]) String() string {
+	if !o.set {
+		return "None"
+	}
+	return fmt.Sprintf("Some(%v)", o.value)
+}
+
+// GoString returns a Go-syntax representation
+func (o Option[T]) GoString() string {
+	if !o.set {
+		return fmt.Sprintf("None[%T]()", o.value)
+	}
+	return fmt.Sprintf("Some[%T](%#v)", o.value, o.value)
+}
+
+// MarshalJSON implements json.Marshaler interface.
+// Some(value) marshals to the value's JSON representation
+// None() marshals to JSON null
+//
+// When used with struct fields:
+//
+//   - None() appears as null by default
+//
+//   - With 'omitzero' tag: None() values are omitted from JSON
+//
+//     type Person struct {
+//     Name    string       `json:"name"`
+//     Age     Option[int]  `json:"age,omitzero"`   // Omitted when None
+//     Address Option[string] `json:"address"`      // Appears as null when None
+//     }
+func (o Option[T]) MarshalJSON() ([]byte, error) {
+	if !o.set {
+		return []byte("null"), nil
+	}
+	return json.Marshal(o.value)
+}
+
+// UnmarshalJSON implements json.Unmarshaler interface.
+// JSON null becomes None(), other values become Some(value)
+func (o *Option[T]) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		*o = None[T]()
+		return nil
+	}
+
+	var value T
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+
+	*o = Some(value)
+	return nil
+}
+
+// IsZero returns 'false' if the value is set, and 'true' if it is not set.
+// It makes Option compatible with the 'omitzero' JSON tag.
+func (o Option[T]) IsZero() bool {
+	return !o.set
+}

--- a/pkg/optional/optional.go
+++ b/pkg/optional/optional.go
@@ -1,4 +1,3 @@
-// Package optional provides an Option type for representing values that may or may not be present.
 package optional
 
 import (

--- a/pkg/optional/optional.go
+++ b/pkg/optional/optional.go
@@ -12,7 +12,7 @@ type Option[T any] struct {
 	set   bool
 }
 
-// Some creates an value that is set
+// Some creates a value that is set
 func Some[T any](value T) Option[T] {
 	return Option[T]{
 		value: value,

--- a/pkg/optional/optional_concurrency_test.go
+++ b/pkg/optional/optional_concurrency_test.go
@@ -1,0 +1,142 @@
+package optional
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCopyIndependence(t *testing.T) {
+	tests := []struct {
+		name string
+		init Option[int]
+		mod  string // JSON to modify copy
+	}{
+		{
+			name: "some to some",
+			init: Some(42),
+			mod:  "99",
+		},
+		{
+			name: "some to none",
+			init: Some(42),
+			mod:  "null",
+		},
+		{
+			name: "none to some",
+			init: None[int](),
+			mod:  "99",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create original option
+			original := tt.init
+
+			// Make a copy
+			copy := original
+
+			// Save original's state
+			origVal, origPresent := original.Get()
+
+			// Modify copy via UnmarshalJSON
+			err := json.Unmarshal([]byte(tt.mod), &copy)
+			require.NoError(t, err)
+
+			// Verify original is unchanged
+			newVal, newPresent := original.Get()
+			assert.Equal(t, origVal, newVal)
+			assert.Equal(t, origPresent, newPresent)
+
+			// Verify copy was changed
+			if tt.mod == "null" {
+				assert.True(t, copy.IsNone())
+			} else {
+				val, ok := copy.Get()
+				assert.True(t, ok)
+				assert.Equal(t, 99, val)
+			}
+		})
+	}
+}
+
+func TestReferenceTypeContainment(t *testing.T) {
+	// Create a map as the inner value
+	m := map[string]int{"key": 1}
+
+	// Create option and copy
+	original := Some(m)
+	copy := original
+
+	// Get maps from both options
+	origMap, origOk := original.Get()
+	require.True(t, origOk)
+
+	copyMap, copyOk := copy.Get()
+	require.True(t, copyOk)
+
+	// Verify we have the same map instance
+	assert.Equal(t, origMap, copyMap)
+
+	// Modify map through copy
+	copyMap["key"] = 2
+
+	// Verify changes visible through original (reference semantics of map)
+	checkMap, _ := original.Get()
+	assert.Equal(t, 2, checkMap["key"])
+
+	// Modify the copy's Option wrapper
+	err := json.Unmarshal([]byte(`null`), &copy)
+	require.NoError(t, err)
+
+	// Original should be unaffected
+	_, stillPresent := original.Get()
+	assert.True(t, stillPresent)
+	assert.False(t, original.IsNone())
+
+	// Copy should be None
+	assert.True(t, copy.IsNone())
+}
+
+func TestMethodImmutability(t *testing.T) {
+	tests := []struct {
+		name   string
+		option Option[int]
+	}{
+		{
+			name:   "some value",
+			option: Some(42),
+		},
+		{
+			name:   "none value",
+			option: None[int](),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Save initial state
+			initialValue, initialPresent := tt.option.Get()
+			initialNone := tt.option.IsNone()
+
+			// Call every non-mutating method
+			_ = tt.option.GetOrElse(0)
+			_ = tt.option.IsNone()
+			_ = tt.option.String()
+			_ = tt.option.GoString()
+			_, _ = tt.option.MarshalJSON()
+			_ = tt.option.IsZero()
+
+			// Verify none of the methods changed the option
+			finalValue, finalPresent := tt.option.Get()
+			finalNone := tt.option.IsNone()
+
+			assert.Equal(t, initialValue, finalValue)
+			assert.Equal(t, initialPresent, finalPresent)
+			assert.Equal(t, initialNone, finalNone)
+		})
+	}
+}

--- a/pkg/optional/optional_test.go
+++ b/pkg/optional/optional_test.go
@@ -1,0 +1,528 @@
+package optional
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSome(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    int
+		expected Option[int]
+	}{
+		{
+			name:     "creates option with integer value",
+			value:    42,
+			expected: Option[int]{value: 42, set: true},
+		},
+		{
+			name:     "creates option with zero value",
+			value:    0,
+			expected: Option[int]{value: 0, set: true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Some(tt.value)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestNone(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected Option[int]
+	}{
+		{
+			name:     "creates empty option",
+			expected: Option[int]{set: false},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := None[int]()
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGet(t *testing.T) {
+	tests := []struct {
+		name          string
+		option        Option[string]
+		expectedValue string
+		expectedSet   bool
+	}{
+		{
+			name:          "gets value from Some",
+			option:        Some("hello"),
+			expectedValue: "hello",
+			expectedSet:   true,
+		},
+		{
+			name:          "gets zero value from None",
+			option:        None[string](),
+			expectedValue: "",
+			expectedSet:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			value, set := tt.option.Get()
+			assert.Equal(t, tt.expectedValue, value)
+			assert.Equal(t, tt.expectedSet, set)
+		})
+	}
+}
+
+func TestMustGet(t *testing.T) {
+	tests := []struct {
+		name          string
+		option        Option[float64]
+		expectedValue float64
+		shouldPanic   bool
+	}{
+		{
+			name:          "gets value from Some",
+			option:        Some(3.14),
+			expectedValue: 3.14,
+			shouldPanic:   false,
+		},
+		{
+			name:        "panics when accessing None",
+			option:      None[float64](),
+			shouldPanic: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.shouldPanic {
+				assert.Panics(t, func() {
+					tt.option.MustGet()
+				})
+			} else {
+				value := tt.option.MustGet()
+				assert.Equal(t, tt.expectedValue, value)
+			}
+		})
+	}
+}
+
+func TestOrElse(t *testing.T) {
+	tests := []struct {
+		name          string
+		option        Option[int]
+		defaultValue  int
+		expectedValue int
+	}{
+		{
+			name:          "returns contained value for Some",
+			option:        Some(42),
+			defaultValue:  0,
+			expectedValue: 42,
+		},
+		{
+			name:          "returns default value for None",
+			option:        None[int](),
+			defaultValue:  99,
+			expectedValue: 99,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.option.GetOrElse(tt.defaultValue)
+			assert.Equal(t, tt.expectedValue, result)
+		})
+	}
+}
+
+func TestIsNone(t *testing.T) {
+	tests := []struct {
+		name     string
+		option   Option[string]
+		expected bool
+	}{
+		{
+			name:     "returns false for Some",
+			option:   Some("value"),
+			expected: false,
+		},
+		{
+			name:     "returns true for None",
+			option:   None[string](),
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.option.IsNone()
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestString(t *testing.T) {
+	tests := []struct {
+		name     string
+		option   Option[int]
+		expected string
+	}{
+		{
+			name:     "formats Some value",
+			option:   Some(42),
+			expected: "Some(42)",
+		},
+		{
+			name:     "formats None",
+			option:   None[int](),
+			expected: "None",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.option.String()
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGoString(t *testing.T) {
+	tests := []struct {
+		name     string
+		option   Option[any]
+		expected string
+	}{
+		{
+			name:     "formats Some value with int",
+			option:   Some[any](42),
+			expected: "Some[int](42)",
+		},
+		{
+			name:     "formats Some value with string",
+			option:   Some[any]("test"),
+			expected: `Some[string]("test")`,
+		},
+		{
+			name:     "formats None",
+			option:   None[any](),
+			expected: "None[<nil>]()",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.option.GoString()
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestMarshalJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		option   Option[any]
+		expected string
+	}{
+		{
+			name:     "marshals Some integer",
+			option:   Some[any](42),
+			expected: "42",
+		},
+		{
+			name:     "marshals Some string",
+			option:   Some[any]("test"),
+			expected: `"test"`,
+		},
+		{
+			name:     "marshals Some object",
+			option:   Some[any](map[string]int{"a": 1}),
+			expected: `{"a":1}`,
+		},
+		{
+			name:     "marshals None as null",
+			option:   None[any](),
+			expected: "null",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.option)
+			require.NoError(t, err)
+			assert.JSONEq(t, tt.expected, string(data))
+		})
+	}
+}
+
+func TestUnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		json     string
+		expected Option[any]
+	}{
+		{
+			name:     "unmarshals integer into Some",
+			json:     "42",
+			expected: Some[any](float64(42)), // JSON numbers unmarshal as float64 by default
+		},
+		{
+			name:     "unmarshals string into Some",
+			json:     `"test"`,
+			expected: Some[any]("test"),
+		},
+		{
+			name:     "unmarshals object into Some",
+			json:     `{"a":1}`,
+			expected: Some[any](map[string]interface{}{"a": float64(1)}),
+		},
+		{
+			name:     "unmarshals null into None",
+			json:     "null",
+			expected: None[any](),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var result Option[any]
+			err := json.Unmarshal([]byte(tt.json), &result)
+			require.NoError(t, err)
+
+			// Check if None or Some
+			assert.Equal(t, tt.expected.IsNone(), result.IsNone())
+
+			if !tt.expected.IsNone() {
+				expectedValue, _ := tt.expected.Get()
+				actualValue, _ := result.Get()
+				assert.Equal(t, expectedValue, actualValue)
+			}
+		})
+	}
+}
+
+// TestUnmarshalJSONEdgeCases tests edge cases for the UnmarshalJSON implementation
+func TestUnmarshalJSONEdgeCases(t *testing.T) {
+	t.Run("invalid json", func(t *testing.T) {
+		var result Option[int]
+		err := json.Unmarshal([]byte("{invalid json}"), &result)
+		assert.Error(t, err)
+	})
+
+	t.Run("type mismatch", func(t *testing.T) {
+		var result Option[int]
+		err := json.Unmarshal([]byte(`"not an int"`), &result)
+		assert.Error(t, err)
+	})
+
+	t.Run("custom json marshaler type", func(t *testing.T) {
+		type CustomType struct {
+			Value string
+		}
+
+		// Create a nested option with a custom type
+		original := Some(Some(CustomType{Value: "test"}))
+		data, err := json.Marshal(original)
+		require.NoError(t, err)
+
+		var result Option[Option[CustomType]]
+		err = json.Unmarshal(data, &result)
+		require.NoError(t, err)
+
+		// Verify the nested structure was preserved
+		val1, set1 := result.Get()
+		assert.True(t, set1)
+
+		val2, set2 := val1.Get()
+		assert.True(t, set2)
+		assert.Equal(t, "test", val2.Value)
+	})
+}
+
+// TestStructWithOptions tests using Option with struct fields
+func TestStructWithOptions(t *testing.T) {
+	type Person struct {
+		Name    string         `json:"name"`
+		Age     Option[int]    `json:"age,omitzero"` // Will be omitted when None
+		Address Option[string] `json:"address"`      // Will be null when None
+	}
+
+	tests := []struct {
+		name     string
+		person   Person
+		expected string
+	}{
+		{
+			name: "all fields present",
+			person: Person{
+				Name:    "Alice",
+				Age:     Some(30),
+				Address: Some("123 Main St"),
+			},
+			expected: `{"name":"Alice","age":30,"address":"123 Main St"}`,
+		},
+		{
+			name: "all optional fields as None",
+			person: Person{
+				Name:    "Bob",
+				Age:     None[int](),
+				Address: None[string](),
+			},
+			expected: `{"name":"Bob","address":null}`, // Age omitted, Address null
+		},
+		{
+			name: "mixed Some and None",
+			person: Person{
+				Name:    "Charlie",
+				Age:     Some(25),
+				Address: None[string](),
+			},
+			expected: `{"name":"Charlie","age":25,"address":null}`, // Address still null
+		},
+		{
+			name: "omitted field but present null field",
+			person: Person{
+				Name:    "Dave",
+				Age:     None[int](),
+				Address: Some("456 Oak St"),
+			},
+			expected: `{"name":"Dave","address":"456 Oak St"}`, // Age omitted
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test marshaling
+			data, err := json.Marshal(tt.person)
+			require.NoError(t, err)
+			assert.JSONEq(t, tt.expected, string(data))
+
+			// Test unmarshaling
+			var result Person
+			err = json.Unmarshal(data, &result)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.person.Name, result.Name)
+
+			origAge, origAgeSet := tt.person.Age.Get()
+			resultAge, resultAgeSet := result.Age.Get()
+			assert.Equal(t, origAgeSet, resultAgeSet)
+			if origAgeSet {
+				assert.Equal(t, origAge, resultAge)
+			}
+
+			origAddr, origAddrSet := tt.person.Address.Get()
+			resultAddr, resultAddrSet := result.Address.Get()
+			assert.Equal(t, origAddrSet, resultAddrSet)
+			if origAddrSet {
+				assert.Equal(t, origAddr, resultAddr)
+			}
+		})
+	}
+}
+
+// TestPtr tests the Ptr function for creating Option values from pointers
+func TestPtr(t *testing.T) {
+	tests := []struct {
+		name     string
+		ptr      *string
+		expected Option[string]
+	}{
+		{
+			name:     "creates Some from non-nil pointer",
+			ptr:      stringPtr("test"),
+			expected: Some("test"),
+		},
+		{
+			name:     "creates None from nil pointer",
+			ptr:      nil,
+			expected: None[string](),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Ptr(tt.ptr)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// Helper function to create string pointers
+func stringPtr(s string) *string {
+	return &s
+}
+
+// TestZeroValueVsNone tests the distinction between a Some with a zero value and None
+func TestZeroValueVsNone(t *testing.T) {
+	tests := []struct {
+		name          string
+		option        Option[any]
+		isNone        bool
+		expectedValue any
+	}{
+		{
+			name:          "Some with zero int",
+			option:        Some[any](0),
+			isNone:        false,
+			expectedValue: 0,
+		},
+		{
+			name:          "Some with empty string",
+			option:        Some[any](""),
+			isNone:        false,
+			expectedValue: "",
+		},
+		{
+			name:          "Some with nil",
+			option:        Some[any](nil),
+			isNone:        false,
+			expectedValue: nil,
+		},
+		{
+			name:          "None",
+			option:        None[any](),
+			isNone:        true,
+			expectedValue: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test IsNone distinguishes None from Some with zero values
+			assert.Equal(t, tt.isNone, tt.option.IsNone())
+
+			// For Some values, verify the value is as expected
+			if !tt.isNone {
+				value, set := tt.option.Get()
+				assert.True(t, set)
+				assert.Equal(t, tt.expectedValue, value)
+			}
+
+			// Verify JSON marshaling works correctly
+			data, err := json.Marshal(tt.option)
+			require.NoError(t, err)
+
+			if tt.isNone {
+				assert.JSONEq(t, "null", string(data))
+			} else if tt.expectedValue == nil {
+				assert.JSONEq(t, "null", string(data))
+			} else {
+				expectedJSON, err := json.Marshal(tt.expectedValue)
+				require.NoError(t, err)
+				assert.JSONEq(t, string(expectedJSON), string(data))
+			}
+		})
+	}
+}

--- a/pkg/optional/primitives.go
+++ b/pkg/optional/primitives.go
@@ -1,0 +1,104 @@
+package optional
+
+// Helpers to construct optional values from primitive types.
+// A user can always use Some(value) to construct an optional value
+// even for primitive types:
+//
+//	opt := optional.Some(42)
+//	opt := optional.Some[float64](42)
+//
+// But the constructors here sometimes make the intent more clear even
+// if they are equivalent:
+//
+//	opt := optional.Int(42)
+//	opt := optional.Float64(42)
+
+// Int returns an Option wrapping the given int value.
+func Int(v int) Option[int] {
+	return Some(v)
+}
+
+// Int8 returns an Option wrapping the given int8 value.
+func Int8(v int8) Option[int8] {
+	return Some(v)
+}
+
+// Int16 returns an Option wrapping the given int16 value.
+func Int16(v int16) Option[int16] {
+	return Some(v)
+}
+
+// Int32 returns an Option wrapping the given int32 value.
+func Int32(v int32) Option[int32] {
+	return Some(v)
+}
+
+// Int64 returns an Option wrapping the given int64 value.
+func Int64(v int64) Option[int64] {
+	return Some(v)
+}
+
+// Uint returns an Option wrapping the given uint value.
+func Uint(v uint) Option[uint] {
+	return Some(v)
+}
+
+// Uint8 returns an Option wrapping the given uint8 value.
+func Uint8(v uint8) Option[uint8] {
+	return Some(v)
+}
+
+// Uint16 returns an Option wrapping the given uint16 value.
+func Uint16(v uint16) Option[uint16] {
+	return Some(v)
+}
+
+// Uint32 returns an Option wrapping the given uint32 value.
+func Uint32(v uint32) Option[uint32] {
+	return Some(v)
+}
+
+// Uint64 returns an Option wrapping the given uint64 value.
+func Uint64(v uint64) Option[uint64] {
+	return Some(v)
+}
+
+// Float32 returns an Option wrapping the given float32 value.
+func Float32(v float32) Option[float32] {
+	return Some(v)
+}
+
+// Float64 returns an Option wrapping the given float64 value.
+func Float64(v float64) Option[float64] {
+	return Some(v)
+}
+
+// Complex64 returns an Option wrapping the given complex64 value.
+func Complex64(v complex64) Option[complex64] {
+	return Some(v)
+}
+
+// Complex128 returns an Option wrapping the given complex128 value.
+func Complex128(v complex128) Option[complex128] {
+	return Some(v)
+}
+
+// Bool returns an Option wrapping the given bool value.
+func Bool(v bool) Option[bool] {
+	return Some(v)
+}
+
+// String returns an Option wrapping the given string value.
+func String(v string) Option[string] {
+	return Some(v)
+}
+
+// Byte returns an Option wrapping the given byte value.
+func Byte(v byte) Option[byte] {
+	return Some(v)
+}
+
+// Rune returns an Option wrapping the given rune value.
+func Rune(v rune) Option[rune] {
+	return Some(v)
+}

--- a/pkg/pointer/doc.go
+++ b/pkg/pointer/doc.go
@@ -1,0 +1,75 @@
+package pointer
+
+// Package pointer offers a collection of helper functions for working with Go pointers in a
+// type-safe and ergonomic way. The utilities fall into three broad categories:
+//
+//   1. Pointer Constructors
+//      For each of Go's built-in numeric, string and boolean types there is a constructor
+//      that takes a value and returns a pointer to that value. These helpers eliminate the
+//      boilerplate of creating a local variable and taking its address when you need to pass
+//      a pointer literal, e.g.
+//
+//          user.Age = pointer.Int(42)   // instead of `v := 42; user.Age = &v`
+//
+//      The type-specific constructors (Int, String, Bool, etc.) exist primarily for code clarity
+//      and readability. The generic Ptr[T] function can be used with any type, including
+//      primitives (e.g., pointer.Ptr(42)), but the specific constructors can make the intent
+//      clearer without requiring type parameters:
+//
+//          // Both of these work, but the first is more readable
+//          score := pointer.Float64(42)         // More idiomatic
+//          score := pointer.Ptr[float64](42)    // Works, but more verbose
+//
+//      The constructors are especially useful when dealing with structs that have pointer fields:
+//
+//          type User struct {
+//              ID       *string
+//              Name     *string
+//              Age      *int
+//              Score    *float64
+//              Active   *bool
+//          }
+//
+//          // Initialize a struct with pointer fields
+//          user := User{
+//              ID:       pointer.String("user123"),
+//              Name:     pointer.String("Alice"),
+//              Age:      pointer.Int(30),
+//              Score:    pointer.Float64(98.5),
+//              Active:   pointer.Bool(true),
+//          }
+//
+//   2. Safe Dereferencing
+//      Value[T] returns the dereferenced value of *T, falling back to the zero value of the
+//      element type when the pointer is nil. This makes it convenient to read optional
+//      pointer fields without additional nil checks:
+//
+//          // Safe even if userAge is nil
+//          age := pointer.Value(userAge) // returns 0 if nil
+//
+//          // Equivalent to:
+//          // var age int
+//          // if userAge != nil {
+//          //     age = *userAge
+//          // }
+//
+//   3. Defaulting Helpers
+//      ValueOr[T] behaves like Value but lets the caller supply an explicit default value to
+//      use when the pointer is nil:
+//
+//          // Returns the dereferenced value if not nil, or 18 if nil
+//          age := pointer.ValueOr(userAge, 18)
+//
+//          // Equivalent to:
+//          // age := 18
+//          // if userAge != nil {
+//          //     age = *userAge
+//          // }
+//
+// All helpers are implemented as small, inlinable one-liners so they impose no runtime cost.
+// They are intended for situations such as:
+//   • Interacting with APIs that use pointer fields to express optional values (e.g. json, yaml).
+//   • Writing concise tests that need pointer literals.
+//   • Reducing repetitive nil checks when consuming optional data.
+//
+// Usage examples can be found in example_test.go within this package.

--- a/pkg/pointer/example_test.go
+++ b/pkg/pointer/example_test.go
@@ -1,0 +1,77 @@
+package pointer_test
+
+import (
+	"fmt"
+
+	"go.jetify.com/pkg/pointer"
+)
+
+// Example demonstrates the basic pointer creation functions.
+func Example() {
+	// Create pointers to primitive values
+	boolPtr := pointer.Bool(true)
+	intPtr := pointer.Int(42)
+	stringPtr := pointer.String("hello")
+
+	// Safely dereference the pointers
+	fmt.Printf("Bool: %v\n", *boolPtr)
+	fmt.Printf("Int: %v\n", *intPtr)
+	fmt.Printf("String: %v\n", *stringPtr)
+
+	// Output:
+	// Bool: true
+	// Int: 42
+	// String: hello
+}
+
+// ExamplePtr demonstrates the use of the generic Ptr function.
+func ExamplePtr() {
+	// Create pointers to primitive values
+	boolPtr := pointer.Ptr(true)
+	intPtr := pointer.Ptr(42)
+	stringPtr := pointer.Ptr("hello")
+
+	// Safely dereference the pointers
+	fmt.Printf("Bool: %v\n", *boolPtr)
+	fmt.Printf("Int: %v\n", *intPtr)
+	fmt.Printf("String: %v\n", *stringPtr)
+
+	// Output:
+	// Bool: true
+	// Int: 42
+	// String: hello
+}
+
+// ExampleValueOr demonstrates the use of the ValueOr function with nil pointers.
+func ExampleValueOr() {
+	var nilStringPtr *string
+	definedStringPtr := pointer.String("defined value")
+
+	// Use ValueOr to handle nil pointers with defaults
+	nilValue := pointer.ValueOr(nilStringPtr, "default value")
+	definedValue := pointer.ValueOr(definedStringPtr, "default value")
+
+	fmt.Printf("Nil pointer value: %s\n", nilValue)
+	fmt.Printf("Defined pointer value: %s\n", definedValue)
+
+	// Output:
+	// Nil pointer value: default value
+	// Defined pointer value: defined value
+}
+
+// ExampleValue demonstrates the use of the Value function.
+func ExampleValue() {
+	var nilIntPtr *int
+	definedIntPtr := pointer.Int(42)
+
+	// Use Value to safely dereference pointers
+	nilValue := pointer.Value(nilIntPtr)
+	definedValue := pointer.Value(definedIntPtr)
+
+	fmt.Printf("Nil pointer value: %d\n", nilValue)
+	fmt.Printf("Defined pointer value: %d\n", definedValue)
+
+	// Output:
+	// Nil pointer value: 0
+	// Defined pointer value: 42
+}

--- a/pkg/pointer/pointer.go
+++ b/pkg/pointer/pointer.go
@@ -1,0 +1,113 @@
+package pointer
+
+// Ptr returns a pointer to the given value.
+func Ptr[T any](v T) *T {
+	return &v
+}
+
+// Int returns a pointer to the given int value.
+func Int(v int) *int {
+	return &v
+}
+
+// Int8 returns a pointer to the given int8 value.
+func Int8(v int8) *int8 {
+	return &v
+}
+
+// Int16 returns a pointer to the given int16 value.
+func Int16(v int16) *int16 {
+	return &v
+}
+
+// Int32 returns a pointer to the given int32 value.
+func Int32(v int32) *int32 {
+	return &v
+}
+
+// Int64 returns a pointer to the given int64 value.
+func Int64(v int64) *int64 {
+	return &v
+}
+
+// Uint returns a pointer to the given uint value.
+func Uint(v uint) *uint {
+	return &v
+}
+
+// Uint8 returns a pointer to the given uint8 value.
+func Uint8(v uint8) *uint8 {
+	return &v
+}
+
+// Uint16 returns a pointer to the given uint16 value.
+func Uint16(v uint16) *uint16 {
+	return &v
+}
+
+// Uint32 returns a pointer to the given uint32 value.
+func Uint32(v uint32) *uint32 {
+	return &v
+}
+
+// Uint64 returns a pointer to the given uint64 value.
+func Uint64(v uint64) *uint64 {
+	return &v
+}
+
+// Float32 returns a pointer to the given float32 value.
+func Float32(v float32) *float32 {
+	return &v
+}
+
+// Float64 returns a pointer to the given float64 value.
+func Float64(v float64) *float64 {
+	return &v
+}
+
+// Complex64 returns a pointer to the given complex64 value.
+func Complex64(v complex64) *complex64 {
+	return &v
+}
+
+// Complex128 returns a pointer to the given complex128 value.
+func Complex128(v complex128) *complex128 {
+	return &v
+}
+
+// Bool returns a pointer to the given bool value.
+func Bool(v bool) *bool {
+	return &v
+}
+
+// String returns a pointer to the given string value.
+func String(v string) *string {
+	return &v
+}
+
+// Byte returns a pointer to the given byte value.
+func Byte(v byte) *byte {
+	return &v
+}
+
+// Rune returns a pointer to the given rune value.
+func Rune(v rune) *rune {
+	return &v
+}
+
+// ValueOr returns the dereferenced value if the pointer is not nil, or the default value otherwise.
+func ValueOr[T any](p *T, defaultValue T) T {
+	if p == nil {
+		return defaultValue
+	}
+	return *p
+}
+
+// Value safely dereferences a pointer, returning the zero value if the pointer is nil.
+func Value[T any](p *T) T {
+	var zero T
+	if p == nil {
+		return zero
+	}
+	return *p
+}


### PR DESCRIPTION
## Summary
This PR does two simple changes:
- It makes our linting rules very close to the ones in Axiom
- It moves the code for the optional on-pointer packages from Axiom to open source. This is a straight copy of the code, with no functionality or logic changes

## How was it tested?
Ran unit tests

## Community Contribution License

All community contributions in this pull request are licensed to the project maintainers under the terms of the [Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request I represent that I have the right to license the contributions to the project maintainers under the Apache 2 License as stated in the [Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).
