### PR TITLE
Start publishing the AI repo

### DIFF
--- a/.github/workflows/publish-repos.yml
+++ b/.github/workflows/publish-repos.yml
@@ -73,6 +73,7 @@ jobs:
           # if you relocate a subdirectory within the monorepo, you need to update this
           # yaml for things to continue to work.
           targets: >
+            aisdk/ai
             envsec
             nixtest
             pkg


### PR DESCRIPTION
## Summary
Update our GitHub Action so that we start publishing the AISDK code from this open source mono repo to the new AI repo. 

## How was it tested?
It wasn't.

## Community Contribution License

All community contributions in this pull request are licensed to the project maintainers under the terms of the [Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request I represent that I have the right to license the contributions to the project maintainers under the Apache 2 License as stated in the [Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).
