### PR TITLE
[AI] Implement streaming in the OpenAI provider

### DIFF
--- a/aisdk/ai/provider/openai/internal/codec/decode.go
+++ b/aisdk/ai/provider/openai/internal/codec/decode.go
@@ -49,7 +49,7 @@ func DecodeResponse(msg *responses.Response) (api.Response, error) {
 		LogProbs: api.LogProbs{},
 	}
 
-	resp.FinishReason = decodeFinishReason(msg, content.HasTools)
+	resp.FinishReason = decodeFinishReason(msg.IncompleteDetails.Reason, content.HasTools)
 
 	return resp, nil
 }
@@ -247,13 +247,9 @@ func decodeUsage(usage responses.ResponseUsage) api.Usage {
 }
 
 // decodeFinishReason converts an OpenAI response status to an AI SDK FinishReason type.
-func decodeFinishReason(msg *responses.Response, hasToolCalls bool) api.FinishReason {
-	if msg == nil {
-		return api.FinishReasonUnknown
-	}
-
+func decodeFinishReason(incompleteReason string, hasToolCalls bool) api.FinishReason {
 	// Determine finish reason based on incomplete details reason
-	switch msg.IncompleteDetails.Reason {
+	switch incompleteReason {
 	case "max_output_tokens":
 		return api.FinishReasonLength
 	case "content_filter":

--- a/aisdk/ai/provider/openai/internal/codec/decode_stream.go
+++ b/aisdk/ai/provider/openai/internal/codec/decode_stream.go
@@ -1,0 +1,371 @@
+package codec
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"iter"
+	"time"
+
+	"errors"
+
+	"github.com/openai/openai-go/packages/param"
+	"github.com/openai/openai-go/responses"
+	"go.jetify.com/ai/api"
+)
+
+// StreamReader is an interface for reading from an SSE stream.
+// This abstraction makes testing easier as we can mock this interface instead of the concrete ssestream.Stream type.
+type StreamReader interface {
+	Next() bool
+	Current() responses.ResponseStreamEventUnion
+	Err() error
+}
+
+// DecodeStream converts an OpenAI SSE stream to our API's StreamResponse.
+// This is the main entry point for decoding OpenAI streams.
+func DecodeStream(stream StreamReader) (api.StreamResponse, error) {
+	decoder := &streamDecoder{}
+	return decoder.DecodeStream(stream)
+}
+
+// streamDecoder maintains state while decoding a stream of OpenAI events.
+type streamDecoder struct {
+	// Map from output index to tool call information
+	ongoingToolCalls map[int64]toolCallInfo
+
+	// Tracking response metadata
+	responseID string
+
+	// Usage statistics
+	promptTokens     int
+	completionTokens int
+
+	// Advanced usage statistics
+	inputCachedTokens     int
+	outputReasoningTokens int
+
+	// Flags
+	hasToolCalls bool
+
+	// Incomplete details for determining finish reason
+	incompleteReason string
+
+	// Counter for source annotations
+	annotationCounter int
+}
+
+// toolCallInfo tracks information about an ongoing tool call.
+type toolCallInfo struct {
+	toolName   string
+	toolCallID string
+}
+
+// DecodeStream processes an OpenAI stream and returns our API stream format.
+func (d *streamDecoder) DecodeStream(stream StreamReader) (api.StreamResponse, error) {
+	if d.ongoingToolCalls == nil {
+		d.ongoingToolCalls = make(map[int64]toolCallInfo)
+	}
+
+	return api.StreamResponse{
+		Events: d.decodeEvents(stream),
+	}, nil
+}
+
+// decodeEvents returns an iterator that yields events from the OpenAI stream.
+func (d *streamDecoder) decodeEvents(stream StreamReader) iter.Seq[api.StreamEvent] {
+	return func(yield func(api.StreamEvent) bool) {
+		// Process all events directly in the iterator function
+		for stream.Next() {
+			// Get the current event
+			event := stream.Current()
+
+			// Process the event
+			decodedEvent := d.decodeEvent(event)
+
+			// Only send non-nil events (this handles events that are processed internally but don't yield output,
+			// and also events that are explicitly decoded to an api.ErrorEvent)
+			if decodedEvent != nil {
+				if !yield(decodedEvent) {
+					return
+				}
+			}
+		}
+
+		// Check if we encountered an error from the underlying stream
+		if err := stream.Err(); err != nil && !errors.Is(err, io.EOF) {
+			// Yield this as a final error event
+			if !yield(&api.ErrorEvent{Err: err}) {
+				// Consumer doesn't want more, even this error
+				return
+			}
+		}
+
+		// Create provider metadata with full usage information
+		metadata := api.NewProviderMetadata(map[string]any{
+			"openai": &Metadata{
+				ResponseID: d.responseID,
+				Usage: Usage{
+					InputTokens:           d.promptTokens,
+					OutputTokens:          d.completionTokens,
+					InputCachedTokens:     d.inputCachedTokens,
+					OutputReasoningTokens: d.outputReasoningTokens,
+				},
+			},
+		})
+
+		// Determine finish reason based on decoder state
+		finishReason := decodeFinishReason(d.incompleteReason, d.hasToolCalls)
+
+		// Send the final finish event
+		yield(&api.FinishEvent{
+			FinishReason: finishReason,
+			Usage: &api.Usage{
+				PromptTokens:     d.promptTokens,
+				CompletionTokens: d.completionTokens,
+			},
+			ProviderMetadata: metadata,
+		})
+	}
+}
+
+// decodeEvent translates an OpenAI event to our API event format.
+// It now returns a single api.StreamEvent, which can be an api.ErrorEvent
+// if an internal processing error occurs or if an OpenAI error event is decoded.
+// It returns nil if the event is known but intentionally not exposed to clients.
+func (d *streamDecoder) decodeEvent(event responses.ResponseStreamEventUnion) api.StreamEvent {
+	switch event.Type {
+	case "response.output_text.delta":
+		return d.decodeTextDelta(event)
+	case "response.output_item.added":
+		return d.decodeOutputItemAdded(event)
+	case "response.function_call_arguments.delta":
+		return d.decodeFunctionCallArgumentsDelta(event)
+	case "response.output_item.done":
+		return d.decodeOutputItemDone(event)
+	case "response.created":
+		return d.decodeResponseCreated(event)
+	case "response.completed":
+		return d.decodeResponseCompleted(event)
+	case "response.failed", "response.incomplete":
+		return d.decodeResponseFailedOrIncomplete(event)
+	case "response.reasoning_summary_text.delta":
+		return d.decodeReasoningSummaryTextDelta(event)
+	case "response.output_text.annotation.added":
+		return d.decodeOutputTextAnnotationAdded(event)
+	case "response.text_annotation.delta":
+		return d.decodeTextAnnotationDelta(event)
+	case "error":
+		return d.decodeError(event)
+	// Event types that we're aware of but don't yet expose to clients:
+	case "response.in_progress",
+		"response.content_part.done",
+		"response.content_part.added",
+		"response.output_text.done",
+		"response.refusal.delta",
+		"response.refusal.done",
+		"response.function_call_arguments.done",
+		"response.file_search_call.in_progress",
+		"response.file_search_call.searching",
+		"response.file_search_call.completed",
+		"response.web_search_call.in_progress",
+		"response.web_search_call.searching",
+		"response.web_search_call.completed",
+		"response.reasoning_summary_part.added",
+		"response.reasoning_summary_part.done",
+		"response.reasoning_summary_text.done",
+		"response.audio.delta",
+		"response.audio.done",
+		"response.audio.transcript.delta",
+		"response.audio.transcript.done",
+		"response.code_interpreter_call.code.delta",
+		"response.code_interpreter_call.code.done",
+		"response.code_interpreter_call.completed",
+		"response.code_interpreter_call.in_progress",
+		"response.code_interpreter_call.interpreting":
+		// We're aware these events exist but we don't expose them to clients yet.
+		return nil
+	default:
+		// Ignore any other unsupported event types
+		// TODO: Return a warning as an api.ErrorEvent?
+		// For now, returning nil to maintain current behavior of ignoring.
+		return nil
+	}
+}
+
+// decodeTextDelta handles text delta events
+func (d *streamDecoder) decodeTextDelta(event responses.ResponseStreamEventUnion) api.StreamEvent {
+	textDelta := event.AsResponseOutputTextDelta()
+	return &api.TextDeltaEvent{
+		TextDelta: textDelta.Delta,
+	}
+}
+
+// decodeOutputItemAdded handles output item added events
+func (d *streamDecoder) decodeOutputItemAdded(event responses.ResponseStreamEventUnion) api.StreamEvent {
+	itemAdded := event.AsResponseOutputItemAdded()
+	item := itemAdded.Item
+
+	if item.Type == "function_call" {
+		funcCall := item.AsFunctionCall()
+
+		// Store the tool call information for later deltas
+		d.ongoingToolCalls[itemAdded.OutputIndex] = toolCallInfo{
+			toolName:   funcCall.Name,
+			toolCallID: funcCall.CallID,
+		}
+		d.hasToolCalls = true
+
+		return &api.ToolCallDeltaEvent{
+			ToolCallID:   funcCall.CallID,
+			ToolCallType: "function",
+			ToolName:     funcCall.Name,
+			ArgsDelta:    []byte(funcCall.Arguments),
+		}
+	}
+
+	if item.Type == "reasoning" {
+		return nil
+	}
+
+	return nil
+}
+
+// decodeFunctionCallArgumentsDelta handles function call arguments delta events
+func (d *streamDecoder) decodeFunctionCallArgumentsDelta(event responses.ResponseStreamEventUnion) api.StreamEvent {
+	argsDelta := event.AsResponseFunctionCallArgumentsDelta()
+	toolCall, exists := d.ongoingToolCalls[argsDelta.OutputIndex]
+
+	if !exists {
+		return &api.ErrorEvent{Err: fmt.Errorf("received function call arguments delta for unknown output index: %d", argsDelta.OutputIndex)}
+	}
+
+	return &api.ToolCallDeltaEvent{
+		ToolCallID:   toolCall.toolCallID,
+		ToolCallType: "function",
+		ToolName:     toolCall.toolName,
+		ArgsDelta:    []byte(argsDelta.Delta),
+	}
+}
+
+// decodeOutputItemDone handles output item done events
+func (d *streamDecoder) decodeOutputItemDone(event responses.ResponseStreamEventUnion) api.StreamEvent {
+	itemDone := event.AsResponseOutputItemDone()
+	item := itemDone.Item
+
+	if item.Type == "function_call" {
+		funcCall := item.AsFunctionCall()
+		delete(d.ongoingToolCalls, itemDone.OutputIndex)
+		return &api.ToolCallEvent{
+			ToolCallID: funcCall.CallID,
+			ToolName:   funcCall.Name,
+			Args:       json.RawMessage(funcCall.Arguments),
+		}
+	}
+	return nil
+}
+
+// decodeResponseCreated handles response created events
+func (d *streamDecoder) decodeResponseCreated(event responses.ResponseStreamEventUnion) api.StreamEvent {
+	created := event.AsResponseCreated()
+	d.responseID = created.Response.ID
+	timestamp := time.Unix(int64(created.Response.CreatedAt), 0).UTC()
+	return &api.ResponseMetadataEvent{
+		ID:        created.Response.ID,
+		Timestamp: &timestamp,
+		ModelID:   created.Response.Model,
+	}
+}
+
+// decodeResponseCompleted handles response completed events
+// This function updates internal state and does not yield an event itself.
+// The final finish event is yielded by the decodeEvents iterator.
+func (d *streamDecoder) decodeResponseCompleted(event responses.ResponseStreamEventUnion) api.StreamEvent {
+	completed := event.AsResponseCompleted()
+	d.promptTokens = int(completed.Response.Usage.InputTokens)
+	d.completionTokens = int(completed.Response.Usage.OutputTokens)
+
+	if !param.IsOmitted(completed.Response.Usage.InputTokensDetails) {
+		d.inputCachedTokens = int(completed.Response.Usage.InputTokensDetails.CachedTokens)
+	}
+	if !param.IsOmitted(completed.Response.Usage.OutputTokensDetails) {
+		d.outputReasoningTokens = int(completed.Response.Usage.OutputTokensDetails.ReasoningTokens)
+	}
+	if completed.Response.IncompleteDetails.Reason != "" {
+		d.incompleteReason = completed.Response.IncompleteDetails.Reason
+	}
+	return nil // No event yielded directly from here
+}
+
+// decodeResponseFailedOrIncomplete handles response failed or incomplete events
+// This function updates internal state and does not yield an event itself.
+// The final finish event's reason is affected, and errors might be reported via FinishEvent.
+func (d *streamDecoder) decodeResponseFailedOrIncomplete(event responses.ResponseStreamEventUnion) api.StreamEvent {
+	var reason string
+	if event.Type == "response.failed" {
+		failedEvent := event.AsResponseFailed()
+		reason = failedEvent.Response.IncompleteDetails.Reason
+		// Potentially, if failedEvent.Response.Error is not nil, we could also emit an ErrorEvent here.
+		// For now, sticking to updating incompleteReason for finish_reason consistency.
+		// if errDetails := failedEvent.Response.Error; errDetails.Code != "" || errDetails.Message != "" {
+		//  // This would be a place to consider if a direct error event is also needed
+		// }
+	} else if event.Type == "response.incomplete" {
+		incompleteEvent := event.AsResponseIncomplete()
+		reason = incompleteEvent.Response.IncompleteDetails.Reason
+	}
+	d.incompleteReason = reason
+	return nil // No event yielded directly from here
+}
+
+// decodeReasoningSummaryTextDelta handles reasoning summary text delta events
+func (d *streamDecoder) decodeReasoningSummaryTextDelta(event responses.ResponseStreamEventUnion) api.StreamEvent {
+	return &api.ReasoningEvent{
+		TextDelta: event.Delta,
+	}
+}
+
+// decodeOutputTextAnnotationAdded handles response.output_text.annotation.added events
+func (d *streamDecoder) decodeOutputTextAnnotationAdded(event responses.ResponseStreamEventUnion) api.StreamEvent {
+	addedEvent := event.AsResponseOutputTextAnnotationAdded()
+	if addedEvent.Annotation.Type == "url_citation" {
+		citation := addedEvent.Annotation.AsURLCitation()
+		sourceEvent := &api.SourceEvent{
+			Source: api.Source{
+				SourceType: "url",
+				ID:         fmt.Sprintf("source-%d", d.annotationCounter),
+				URL:        citation.URL,
+				Title:      citation.Title,
+			},
+		}
+		d.annotationCounter++
+		return sourceEvent
+	}
+	return nil
+}
+
+// decodeTextAnnotationDelta handles response.text_annotation.delta events
+func (d *streamDecoder) decodeTextAnnotationDelta(event responses.ResponseStreamEventUnion) api.StreamEvent {
+	if event.Annotation.Type == "url_citation" {
+		citation := event.Annotation.AsURLCitation()
+		sourceEvent := &api.SourceEvent{
+			Source: api.Source{
+				SourceType: "url",
+				ID:         fmt.Sprintf("source-%d", d.annotationCounter),
+				URL:        citation.URL,
+				Title:      citation.Title,
+			},
+		}
+		d.annotationCounter++
+		return sourceEvent
+	}
+	return nil
+}
+
+// decodeError handles error events from the OpenAI stream
+func (d *streamDecoder) decodeError(event responses.ResponseStreamEventUnion) api.StreamEvent {
+	errorEvent := event.AsError()
+	return &api.ErrorEvent{
+		Err: fmt.Errorf("%s: %s", errorEvent.Code, errorEvent.Message),
+	}
+}

--- a/aisdk/ai/provider/openai/internal/codec/decode_stream.go
+++ b/aisdk/ai/provider/openai/internal/codec/decode_stream.go
@@ -2,12 +2,11 @@ package codec
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"iter"
 	"time"
-
-	"errors"
 
 	"github.com/openai/openai-go/packages/param"
 	"github.com/openai/openai-go/responses"

--- a/aisdk/ai/provider/openai/internal/codec/decode_stream_test.go
+++ b/aisdk/ai/provider/openai/internal/codec/decode_stream_test.go
@@ -1,0 +1,153 @@
+package codec
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/openai/openai-go/responses"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.jetify.com/ai/api"
+	"go.jetify.com/pkg/pointer"
+)
+
+func TestDecodeStreamEvents(t *testing.T) {
+	tests := []struct {
+		name       string
+		eventJSONs []string
+		want       []api.StreamEvent
+	}{
+		{
+			name: "simple text stream",
+			eventJSONs: []string{
+				`{"type": "response.created", "response": {"id": "resp_123", "created_at": 1741269019, "model": "gpt-4"}}`,
+				`{"type": "response.output_text.delta", "delta": "Hello world"}`,
+				`{"type": "response.completed", "response": {"usage": {"input_tokens": 10, "output_tokens": 5}}}`,
+			},
+			want: []api.StreamEvent{
+				&api.ResponseMetadataEvent{
+					ID:        "resp_123",
+					Timestamp: pointer.Ptr(time.Date(2025, 3, 6, 13, 50, 19, 0, time.UTC)),
+					ModelID:   "gpt-4",
+				},
+				&api.TextDeltaEvent{
+					TextDelta: "Hello world",
+				},
+				&api.FinishEvent{
+					FinishReason: api.FinishReasonStop,
+					Usage: &api.Usage{
+						PromptTokens:     10,
+						CompletionTokens: 5,
+					},
+					ProviderMetadata: api.NewProviderMetadata(map[string]any{
+						"openai": &Metadata{
+							ResponseID: "resp_123",
+							Usage: Usage{
+								InputTokens:  10,
+								OutputTokens: 5,
+							},
+						},
+					}),
+				},
+			},
+		},
+		{
+			name: "tool call stream",
+			eventJSONs: []string{
+				`{"type": "response.created", "response": {"id": "resp_456", "created_at": 1741269019, "model": "gpt-4"}}`,
+				`{"type": "response.output_item.added", "output_index": 0, "item": {"type": "function_call", "call_id": "call_123", "name": "get_weather", "arguments": "{\"location\":\"New York\"}"}}`,
+				`{"type": "response.completed", "response": {"usage": {"input_tokens": 15, "output_tokens": 8}}}`,
+			},
+			want: []api.StreamEvent{
+				&api.ResponseMetadataEvent{
+					ID:        "resp_456",
+					Timestamp: pointer.Ptr(time.Date(2025, 3, 6, 13, 50, 19, 0, time.UTC)),
+					ModelID:   "gpt-4",
+				},
+				&api.ToolCallDeltaEvent{
+					ToolCallID:   "call_123",
+					ToolCallType: "function",
+					ToolName:     "get_weather",
+					ArgsDelta:    []byte(`{"location":"New York"}`),
+				},
+				&api.FinishEvent{
+					FinishReason: api.FinishReasonToolCalls,
+					Usage: &api.Usage{
+						PromptTokens:     15,
+						CompletionTokens: 8,
+					},
+					ProviderMetadata: api.NewProviderMetadata(map[string]any{
+						"openai": &Metadata{
+							ResponseID: "resp_456",
+							Usage: Usage{
+								InputTokens:  15,
+								OutputTokens: 8,
+							},
+						},
+					}),
+				},
+			},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			// Parse the JSON events
+			var events []responses.ResponseStreamEventUnion
+			for _, jsonStr := range testCase.eventJSONs {
+				var event responses.ResponseStreamEventUnion
+				err := json.Unmarshal([]byte(jsonStr), &event)
+				require.NoError(t, err)
+				events = append(events, event)
+			}
+
+			// Create a mock stream
+			stream := newMockStreamReader(events)
+
+			// Decode the stream
+			result, err := DecodeStream(stream)
+			require.NoError(t, err)
+
+			// Collect all events from the stream
+			var got []api.StreamEvent
+			for event := range result.Events {
+				got = append(got, event)
+			}
+
+			// Compare events using deep equality
+			assert.Equal(t, testCase.want, got)
+		})
+	}
+}
+
+// mockStreamReader implements the StreamReader interface for testing
+type mockStreamReader struct {
+	events []responses.ResponseStreamEventUnion
+	index  int
+	err    error
+}
+
+// newMockStreamReader creates a new mock stream reader with the given events
+func newMockStreamReader(events []responses.ResponseStreamEventUnion) *mockStreamReader {
+	return &mockStreamReader{
+		events: events,
+		index:  -1,
+	}
+}
+
+// Next advances to the next event, returning true if there is one, false otherwise
+func (m *mockStreamReader) Next() bool {
+	m.index++
+	return m.index < len(m.events)
+}
+
+// Current returns the current event
+func (m *mockStreamReader) Current() responses.ResponseStreamEventUnion {
+	return m.events[m.index]
+}
+
+// Err returns any error that occurred while reading the stream
+func (m *mockStreamReader) Err() error {
+	return m.err
+}

--- a/aisdk/ai/provider/openai/llm.go
+++ b/aisdk/ai/provider/openai/llm.go
@@ -98,5 +98,17 @@ func (m *LanguageModel) Generate(
 func (m *LanguageModel) Stream(
 	ctx context.Context, prompt []api.Message, opts api.CallOptions,
 ) (api.StreamResponse, error) {
-	return api.StreamResponse{}, api.NewUnsupportedFunctionalityError("streaming generation", "")
+	params, warnings, err := codec.Encode(m.modelID, prompt, opts)
+	if err != nil {
+		return api.StreamResponse{}, err
+	}
+
+	stream := m.client.Responses.NewStreaming(ctx, params)
+	response, err := codec.DecodeStream(stream)
+	if err != nil {
+		return api.StreamResponse{}, err
+	}
+
+	response.Warnings = append(response.Warnings, warnings...)
+	return response, nil
 }

--- a/aisdk/ai/provider/openai/llm_test.go
+++ b/aisdk/ai/provider/openai/llm_test.go
@@ -2927,13 +2927,13 @@ func runGenerateTests(t *testing.T, tests []struct {
 	skip         bool
 },
 ) {
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if tt.skip {
-				t.Skipf("Skipping test: %s", tt.name)
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			if testCase.skip {
+				t.Skipf("Skipping test: %s", testCase.name)
 			}
 
-			server := httpmock.NewServer(t, tt.exchanges)
+			server := httpmock.NewServer(t, testCase.exchanges)
 			defer server.Close()
 
 			// Set up client options for the OpenAI client
@@ -2947,15 +2947,15 @@ func runGenerateTests(t *testing.T, tests []struct {
 			client := openai.NewClient(clientOptions...)
 
 			// Use custom model ID
-			modelID := tt.modelID
+			modelID := testCase.modelID
 
 			// Create model with mocked client
 			model := NewLanguageModel(modelID, WithClient(client))
 
 			// Call Generate with the test's options (or empty if not specified)
-			resp, err := model.Generate(t.Context(), tt.prompt, tt.options)
+			resp, err := model.Generate(t.Context(), testCase.prompt, testCase.options)
 
-			if tt.wantErr {
+			if testCase.wantErr {
 				require.Error(t, err)
 				return
 			}
@@ -2964,7 +2964,7 @@ func runGenerateTests(t *testing.T, tests []struct {
 			require.NotNil(t, resp)
 
 			// Use aitesting.ResponseContains to verify expected response fields
-			aitesting.ResponseContains(t, tt.expectedResp, resp)
+			aitesting.ResponseContains(t, testCase.expectedResp, resp)
 		})
 	}
 }
@@ -2978,14 +2978,15 @@ func runStreamTests(t *testing.T, tests []struct {
 	wantErr        bool
 	expectedEvents []api.StreamEvent
 	skip           bool
-}) {
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if tt.skip {
-				t.Skipf("Skipping test: %s", tt.name)
+},
+) {
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			if testCase.skip {
+				t.Skipf("Skipping test: %s", testCase.name)
 			}
 
-			server := httpmock.NewServer(t, tt.exchanges)
+			server := httpmock.NewServer(t, testCase.exchanges)
 			defer server.Close()
 
 			// Set up client options for the OpenAI client
@@ -2999,15 +3000,15 @@ func runStreamTests(t *testing.T, tests []struct {
 			client := openai.NewClient(clientOptions...)
 
 			// Use custom model ID
-			modelID := tt.modelID
+			modelID := testCase.modelID
 
 			// Create model with mocked client
 			model := NewLanguageModel(modelID, WithClient(client))
 
 			// Call Stream with the test's options (or empty if not specified)
-			resp, err := model.Stream(t.Context(), tt.prompt, tt.options)
+			resp, err := model.Stream(t.Context(), testCase.prompt, testCase.options)
 
-			if tt.wantErr {
+			if testCase.wantErr {
 				require.Error(t, err)
 				return
 			}
@@ -3022,7 +3023,7 @@ func runStreamTests(t *testing.T, tests []struct {
 			}
 
 			// Compare events using deep equality
-			require.Equal(t, tt.expectedEvents, gotEvents)
+			require.Equal(t, testCase.expectedEvents, gotEvents)
 		})
 	}
 }

--- a/aisdk/ai/provider/openai/llm_test.go
+++ b/aisdk/ai/provider/openai/llm_test.go
@@ -1,9 +1,12 @@
 package openai
 
 import (
+	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/openai/openai-go"
 	"github.com/openai/openai-go/option"
@@ -13,7 +16,34 @@ import (
 	"go.jetify.com/ai/api"
 	"go.jetify.com/ai/provider/openai/internal/codec"
 	"go.jetify.com/pkg/httpmock"
+	"go.jetify.com/pkg/pointer"
+	"go.jetify.com/sse"
 )
+
+var standardTools = []api.ToolDefinition{
+	&api.FunctionTool{
+		Name: "weather",
+		InputSchema: &jsonschema.Definition{
+			Type: jsonschema.Object,
+			Properties: map[string]jsonschema.Definition{
+				"location": {Type: jsonschema.String},
+			},
+			Required:             []string{"location"},
+			AdditionalProperties: false,
+		},
+	},
+	&api.FunctionTool{
+		Name: "cityAttractions",
+		InputSchema: &jsonschema.Definition{
+			Type: jsonschema.Object,
+			Properties: map[string]jsonschema.Definition{
+				"city": {Type: jsonschema.String},
+			},
+			Required:             []string{"city"},
+			AdditionalProperties: false,
+		},
+	},
+}
 
 func TestGenerate(t *testing.T) {
 	standardPrompt := []api.Message{
@@ -166,7 +196,7 @@ func TestGenerate(t *testing.T) {
 				// TODO: We should have a better way for setting temperature.
 				// The field should either be a float, or if it's a pointer, we need to include
 				// helper functions as part of the API.
-				Temperature: float64Ptr(0.5),
+				Temperature: pointer.Ptr(0.5),
 				TopP:        0.3,
 			},
 			exchanges: []httpmock.Exchange{
@@ -219,7 +249,7 @@ func TestGenerate(t *testing.T) {
 				},
 			},
 			options: api.CallOptions{
-				Temperature: float64Ptr(0.5),
+				Temperature: pointer.Ptr(0.5),
 				TopP:        0.3,
 			},
 			exchanges: []httpmock.Exchange{
@@ -280,7 +310,7 @@ func TestGenerate(t *testing.T) {
 				},
 			},
 			options: api.CallOptions{
-				Temperature: float64Ptr(0.5),
+				Temperature: pointer.Ptr(0.5),
 				TopP:        0.3,
 			},
 			exchanges: []httpmock.Exchange{
@@ -451,7 +481,7 @@ func TestGenerate(t *testing.T) {
 			options: api.CallOptions{
 				ProviderMetadata: api.NewProviderMetadata(map[string]any{
 					"openai": &Metadata{
-						ParallelToolCalls: boolPtr(false),
+						ParallelToolCalls: pointer.Ptr(false),
 					},
 				}),
 			},
@@ -494,7 +524,7 @@ func TestGenerate(t *testing.T) {
 			options: api.CallOptions{
 				ProviderMetadata: api.NewProviderMetadata(map[string]any{
 					"openai": &Metadata{
-						Store: boolPtr(false),
+						Store: pointer.Ptr(false),
 					},
 				}),
 			},
@@ -949,7 +979,7 @@ func TestGenerate(t *testing.T) {
 				},
 				ProviderMetadata: api.NewProviderMetadata(map[string]any{
 					"openai": &Metadata{
-						StrictSchemas: boolPtr(false),
+						StrictSchemas: pointer.Ptr(false),
 					},
 				}),
 			},
@@ -1181,31 +1211,6 @@ func TestGenerate_ToolCalls(t *testing.T) {
 	standardPrompt := []api.Message{
 		&api.UserMessage{
 			Content: api.ContentFromText("Hello"),
-		},
-	}
-
-	standardTools := []api.ToolDefinition{
-		&api.FunctionTool{
-			Name: "weather",
-			InputSchema: &jsonschema.Definition{
-				Type: jsonschema.Object,
-				Properties: map[string]jsonschema.Definition{
-					"location": {Type: jsonschema.String},
-				},
-				Required:             []string{"location"},
-				AdditionalProperties: false,
-			},
-		},
-		&api.FunctionTool{
-			Name: "cityAttractions",
-			InputSchema: &jsonschema.Definition{
-				Type: jsonschema.Object,
-				Properties: map[string]jsonschema.Definition{
-					"city": {Type: jsonschema.String},
-				},
-				Required:             []string{"city"},
-				AdditionalProperties: false,
-			},
 		},
 	}
 
@@ -1610,14 +1615,1305 @@ func TestGenerate_WebSearch(t *testing.T) {
 	runGenerateTests(t, tests)
 }
 
-// Helper function for float64 pointer
-func float64Ptr(v float64) *float64 {
-	return &v
+// eventsToString converts a slice of SSE events to a string format expected by the mock server
+func eventsToString(events []sse.Event) string {
+	var buf bytes.Buffer
+	enc := sse.NewEncoder(&buf)
+	for _, event := range events {
+		if err := enc.EncodeEvent(&event); err != nil {
+			panic(fmt.Sprintf("failed to encode event: %v", err))
+		}
+	}
+	// Add the [DONE] marker
+	buf.WriteString("data: [DONE]\n\n")
+	return buf.String()
 }
 
-// Helper function for boolean pointer
-func boolPtr(v bool) *bool {
-	return &v
+func TestStream(t *testing.T) {
+	standardPrompt := []api.Message{
+		&api.UserMessage{
+			Content: api.ContentFromText("Hello"),
+		},
+	}
+
+	tests := []struct {
+		name           string
+		modelID        string
+		options        api.CallOptions
+		prompt         []api.Message
+		exchanges      []httpmock.Exchange
+		wantErr        bool
+		expectedEvents []api.StreamEvent
+		skip           bool
+	}{
+		{
+			name:    "should stream text deltas",
+			modelID: "gpt-4o",
+			prompt:  standardPrompt,
+			exchanges: []httpmock.Exchange{
+				{
+					Request: httpmock.Request{
+						Method: http.MethodPost,
+						Path:   "/responses",
+					},
+					Response: httpmock.Response{
+						StatusCode: http.StatusOK,
+						Headers: map[string]string{
+							"Content-Type": "text/event-stream",
+						},
+						Body: eventsToString([]sse.Event{
+							{
+								Data: map[string]any{
+									"type": "response.created",
+									"response": map[string]any{
+										"id":         "resp_67c9a81b6a048190a9ee441c5755a4e8",
+										"object":     "response",
+										"created_at": 1741269019,
+										"status":     "in_progress",
+										"model":      "gpt-4o-2024-07-18",
+									},
+								},
+							},
+							{
+								Data: map[string]any{
+									"type": "response.in_progress",
+									"response": map[string]any{
+										"id":         "resp_67c9a81b6a048190a9ee441c5755a4e8",
+										"object":     "response",
+										"created_at": 1741269019,
+										"status":     "in_progress",
+										"model":      "gpt-4o-2024-07-18",
+									},
+								},
+							},
+							{
+								Data: map[string]any{
+									"type":         "response.output_item.added",
+									"output_index": 0,
+									"item": map[string]any{
+										"id":      "msg_67c9a81dea8c8190b79651a2b3adf91e",
+										"type":    "message",
+										"status":  "in_progress",
+										"role":    "assistant",
+										"content": []any{},
+									},
+								},
+							},
+							{
+								Data: map[string]any{
+									"type":          "response.content_part.added",
+									"item_id":       "msg_67c9a81dea8c8190b79651a2b3adf91e",
+									"output_index":  0,
+									"content_index": 0,
+									"part": map[string]any{
+										"type":        "output_text",
+										"text":        "",
+										"annotations": []any{},
+									},
+								},
+							},
+							{
+								Data: map[string]any{
+									"type":          "response.output_text.delta",
+									"item_id":       "msg_67c9a81dea8c8190b79651a2b3adf91e",
+									"output_index":  0,
+									"content_index": 0,
+									"delta":         "Hello,",
+								},
+							},
+							{
+								Data: map[string]any{
+									"type":          "response.output_text.delta",
+									"item_id":       "msg_67c9a81dea8c8190b79651a2b3adf91e",
+									"output_index":  0,
+									"content_index": 0,
+									"delta":         " World!",
+								},
+							},
+							{
+								Data: map[string]any{
+									"type":          "response.output_text.done",
+									"item_id":       "msg_67c9a8787f4c8190b49c858d4c1cf20c",
+									"output_index":  0,
+									"content_index": 0,
+									"text":          "Hello, World!",
+								},
+							},
+							{
+								Data: map[string]any{
+									"type":          "response.content_part.done",
+									"item_id":       "msg_67c9a8787f4c8190b49c858d4c1cf20c",
+									"output_index":  0,
+									"content_index": 0,
+									"part": map[string]any{
+										"type":        "output_text",
+										"text":        "Hello, World!",
+										"annotations": []any{},
+									},
+								},
+							},
+							{
+								Data: map[string]any{
+									"type":         "response.output_item.done",
+									"output_index": 0,
+									"item": map[string]any{
+										"id":     "msg_67c9a8787f4c8190b49c858d4c1cf20c",
+										"type":   "message",
+										"status": "completed",
+										"role":   "assistant",
+										"content": []any{
+											map[string]any{
+												"type":        "output_text",
+												"text":        "Hello, World!",
+												"annotations": []any{},
+											},
+										},
+									},
+								},
+							},
+							{
+								Data: map[string]any{
+									"type": "response.completed",
+									"response": map[string]any{
+										"id":         "resp_67c9a878139c8190aa2e3105411b408b",
+										"object":     "response",
+										"created_at": 1741269112,
+										"status":     "completed",
+										"model":      "gpt-4o-2024-07-18",
+										"output": []any{
+											map[string]any{
+												"id":     "msg_67c9a8787f4c8190b49c858d4c1cf20c",
+												"type":   "message",
+												"status": "completed",
+												"role":   "assistant",
+												"content": []any{
+													map[string]any{
+														"type":        "output_text",
+														"text":        "Hello, World!",
+														"annotations": []any{},
+													},
+												},
+											},
+										},
+										"usage": map[string]any{
+											"input_tokens": 543,
+											"input_tokens_details": map[string]any{
+												"cached_tokens": 234,
+											},
+											"output_tokens": 478,
+											"output_tokens_details": map[string]any{
+												"reasoning_tokens": 123,
+											},
+											"total_tokens": 512,
+										},
+									},
+								},
+							},
+						}),
+					},
+				},
+			},
+			expectedEvents: []api.StreamEvent{
+				&api.ResponseMetadataEvent{
+					ID:        "resp_67c9a81b6a048190a9ee441c5755a4e8",
+					ModelID:   "gpt-4o-2024-07-18",
+					Timestamp: pointer.Ptr(time.Date(2025, 3, 6, 13, 50, 19, 0, time.UTC)),
+				},
+				&api.TextDeltaEvent{
+					TextDelta: "Hello,",
+				},
+				&api.TextDeltaEvent{
+					TextDelta: " World!",
+				},
+				&api.FinishEvent{
+					FinishReason: api.FinishReasonStop,
+					Usage: &api.Usage{
+						PromptTokens:     543,
+						CompletionTokens: 478,
+					},
+					ProviderMetadata: api.NewProviderMetadata(map[string]any{
+						"openai": &Metadata{
+							ResponseID: "resp_67c9a81b6a048190a9ee441c5755a4e8",
+							Usage: codec.Usage{
+								InputTokens:           543,
+								OutputTokens:          478,
+								InputCachedTokens:     234,
+								OutputReasoningTokens: 123,
+							},
+						},
+					}),
+				},
+			},
+		},
+		{
+			name:    "should send finish reason for incomplete response",
+			modelID: "gpt-4o",
+			prompt:  standardPrompt,
+			exchanges: []httpmock.Exchange{
+				{
+					Request: httpmock.Request{
+						Method: http.MethodPost,
+						Path:   "/responses",
+					},
+					Response: httpmock.Response{
+						StatusCode: http.StatusOK,
+						Headers: map[string]string{
+							"Content-Type": "text/event-stream",
+						},
+						Body: eventsToString([]sse.Event{
+							{
+								Data: map[string]any{
+									"type": "response.created",
+									"response": map[string]any{
+										"id":         "resp_67c9a81b6a048190a9ee441c5755a4e8",
+										"object":     "response",
+										"created_at": 1741269019,
+										"status":     "in_progress",
+										"model":      "gpt-4o-2024-07-18",
+									},
+								},
+							},
+							{
+								Data: map[string]any{
+									"type": "response.in_progress",
+									"response": map[string]any{
+										"id":         "resp_67c9a81b6a048190a9ee441c5755a4e8",
+										"object":     "response",
+										"created_at": 1741269019,
+										"status":     "in_progress",
+										"model":      "gpt-4o-2024-07-18",
+									},
+								},
+							},
+							{
+								Data: map[string]any{
+									"type":         "response.output_item.added",
+									"output_index": 0,
+									"item": map[string]any{
+										"id":      "msg_67c9a81dea8c8190b79651a2b3adf91e",
+										"type":    "message",
+										"status":  "in_progress",
+										"role":    "assistant",
+										"content": []any{},
+									},
+								},
+							},
+							{
+								Data: map[string]any{
+									"type":          "response.content_part.added",
+									"item_id":       "msg_67c9a81dea8c8190b79651a2b3adf91e",
+									"output_index":  0,
+									"content_index": 0,
+									"part": map[string]any{
+										"type":        "output_text",
+										"text":        "",
+										"annotations": []any{},
+									},
+								},
+							},
+							{
+								Data: map[string]any{
+									"type":          "response.output_text.delta",
+									"item_id":       "msg_67c9a81dea8c8190b79651a2b3adf91e",
+									"output_index":  0,
+									"content_index": 0,
+									"delta":         "Hello,",
+								},
+							},
+							{
+								Data: map[string]any{
+									"type":          "response.output_text.done",
+									"item_id":       "msg_67c9a8787f4c8190b49c858d4c1cf20c",
+									"output_index":  0,
+									"content_index": 0,
+									"text":          "Hello,!",
+								},
+							},
+							{
+								Data: map[string]any{
+									"type":          "response.content_part.done",
+									"item_id":       "msg_67c9a8787f4c8190b49c858d4c1cf20c",
+									"output_index":  0,
+									"content_index": 0,
+									"part": map[string]any{
+										"type":        "output_text",
+										"text":        "Hello,",
+										"annotations": []any{},
+									},
+								},
+							},
+							{
+								Data: map[string]any{
+									"type":         "response.output_item.done",
+									"output_index": 0,
+									"item": map[string]any{
+										"id":     "msg_67c9a8787f4c8190b49c858d4c1cf20c",
+										"type":   "message",
+										"status": "incomplete",
+										"role":   "assistant",
+										"content": []any{
+											map[string]any{
+												"type":        "output_text",
+												"text":        "Hello,",
+												"annotations": []any{},
+											},
+										},
+									},
+								},
+							},
+							{
+								Data: map[string]any{
+									"type": "response.incomplete",
+									"response": map[string]any{
+										"id":         "resp_67cadb40a0708190ac2763c0b6960f6f",
+										"object":     "response",
+										"created_at": 1741347648,
+										"status":     "incomplete",
+										"incomplete_details": map[string]any{
+											"reason": "max_output_tokens",
+										},
+										"model": "gpt-4o-2024-07-18",
+										"output": []any{
+											map[string]any{
+												"type":   "message",
+												"id":     "msg_67cadb410ccc81909fe1d8f427b9cf02",
+												"status": "incomplete",
+												"role":   "assistant",
+												"content": []any{
+													map[string]any{
+														"type":        "output_text",
+														"text":        "Hello,",
+														"annotations": []any{},
+													},
+												},
+											},
+										},
+										"max_output_tokens": 100,
+									},
+								},
+							},
+						}),
+					},
+				},
+			},
+			expectedEvents: []api.StreamEvent{
+				&api.ResponseMetadataEvent{
+					ID:        "resp_67c9a81b6a048190a9ee441c5755a4e8",
+					ModelID:   "gpt-4o-2024-07-18",
+					Timestamp: pointer.Ptr(time.Date(2025, 3, 6, 13, 50, 19, 0, time.UTC)),
+				},
+				&api.TextDeltaEvent{
+					TextDelta: "Hello,",
+				},
+				&api.FinishEvent{
+					FinishReason: api.FinishReasonLength,
+					Usage: &api.Usage{
+						PromptTokens:     0,
+						CompletionTokens: 0,
+					},
+					ProviderMetadata: api.NewProviderMetadata(map[string]any{
+						"openai": &Metadata{
+							ResponseID: "resp_67c9a81b6a048190a9ee441c5755a4e8",
+							Usage:      codec.Usage{},
+						},
+					}),
+				},
+			},
+		},
+		{
+			name:    "should stream tool calls",
+			modelID: "gpt-4o",
+			prompt:  standardPrompt,
+			options: api.CallOptions{
+				Mode: api.RegularMode{
+					Tools: standardTools,
+				},
+			},
+			exchanges: []httpmock.Exchange{
+				{
+					Request: httpmock.Request{
+						Method: http.MethodPost,
+						Path:   "/responses",
+					},
+					Response: httpmock.Response{
+						StatusCode: http.StatusOK,
+						Headers: map[string]string{
+							"Content-Type": "text/event-stream",
+						},
+						Body: eventsToString([]sse.Event{
+							{
+								Data: map[string]any{
+									"type": "response.created",
+									"response": map[string]any{
+										"id":         "resp_67cb13a755c08190acbe3839a49632fc",
+										"object":     "response",
+										"created_at": 1741362087,
+										"status":     "in_progress",
+										"model":      "gpt-4o-2024-07-18",
+										"tools": []any{
+											map[string]any{
+												"type":        "function",
+												"description": "Get the current location.",
+												"name":        "currentLocation",
+												"parameters": map[string]any{
+													"type":                 "object",
+													"properties":           map[string]any{},
+													"additionalProperties": false,
+												},
+												"strict": true,
+											},
+											map[string]any{
+												"type":        "function",
+												"description": "Get the weather in a location",
+												"name":        "weather",
+												"parameters": map[string]any{
+													"type": "object",
+													"properties": map[string]any{
+														"location": map[string]any{
+															"type":        "string",
+															"description": "The location to get the weather for",
+														},
+													},
+													"required":             []string{"location"},
+													"additionalProperties": false,
+												},
+												"strict": true,
+											},
+										},
+									},
+								},
+							},
+							{
+								Data: map[string]any{
+									"type": "response.in_progress",
+									"response": map[string]any{
+										"id":         "resp_67cb13a755c08190acbe3839a49632fc",
+										"object":     "response",
+										"created_at": 1741362087,
+										"status":     "in_progress",
+										"model":      "gpt-4o-2024-07-18",
+										"tools": []any{
+											map[string]any{
+												"type":        "function",
+												"description": "Get the current location.",
+												"name":        "currentLocation",
+												"parameters": map[string]any{
+													"type":                 "object",
+													"properties":           map[string]any{},
+													"additionalProperties": false,
+												},
+												"strict": true,
+											},
+											map[string]any{
+												"type":        "function",
+												"description": "Get the weather in a location",
+												"name":        "weather",
+												"parameters": map[string]any{
+													"type": "object",
+													"properties": map[string]any{
+														"location": map[string]any{
+															"type":        "string",
+															"description": "The location to get the weather for",
+														},
+													},
+													"required":             []string{"location"},
+													"additionalProperties": false,
+												},
+												"strict": true,
+											},
+										},
+									},
+								},
+							},
+							{
+								Data: map[string]any{
+									"type":         "response.output_item.added",
+									"output_index": 0,
+									"item": map[string]any{
+										"type":      "function_call",
+										"id":        "fc_67cb13a838088190be08eb3927c87501",
+										"call_id":   "call_6KxSghkb4MVnunFH2TxPErLP",
+										"name":      "currentLocation",
+										"arguments": "",
+										"status":    "completed",
+									},
+								},
+							},
+							{
+								Data: map[string]any{
+									"type":         "response.function_call_arguments.delta",
+									"item_id":      "fc_67cb13a838088190be08eb3927c87501",
+									"output_index": 0,
+									"delta":        "{}",
+								},
+							},
+							{
+								Data: map[string]any{
+									"type":         "response.function_call_arguments.done",
+									"item_id":      "fc_67cb13a838088190be08eb3927c87501",
+									"output_index": 0,
+									"arguments":    "{}",
+								},
+							},
+							{
+								Data: map[string]any{
+									"type":         "response.output_item.done",
+									"output_index": 0,
+									"item": map[string]any{
+										"type":      "function_call",
+										"id":        "fc_67cb13a838088190be08eb3927c87501",
+										"call_id":   "call_pgjcAI4ZegMkP6bsAV7sfrJA",
+										"name":      "currentLocation",
+										"arguments": "{}",
+										"status":    "completed",
+									},
+								},
+							},
+							{
+								Data: map[string]any{
+									"type":         "response.output_item.added",
+									"output_index": 1,
+									"item": map[string]any{
+										"type":      "function_call",
+										"id":        "fc_67cb13a858f081908a600343fa040f47",
+										"call_id":   "call_Dg6WUmFHNeR5JxX1s53s1G4b",
+										"name":      "weather",
+										"arguments": "",
+										"status":    "in_progress",
+									},
+								},
+							},
+							{
+								Data: map[string]any{
+									"type":         "response.function_call_arguments.delta",
+									"item_id":      "fc_67cb13a858f081908a600343fa040f47",
+									"output_index": 1,
+									"delta":        "{",
+								},
+							},
+							{
+								Data: map[string]any{
+									"type":         "response.function_call_arguments.delta",
+									"item_id":      "fc_67cb13a858f081908a600343fa040f47",
+									"output_index": 1,
+									"delta":        "\"location\"",
+								},
+							},
+							{
+								Data: map[string]any{
+									"type":         "response.function_call_arguments.delta",
+									"item_id":      "fc_67cb13a858f081908a600343fa040f47",
+									"output_index": 1,
+									"delta":        "\":\"",
+								},
+							},
+							{
+								Data: map[string]any{
+									"type":         "response.function_call_arguments.delta",
+									"item_id":      "fc_67cb13a858f081908a600343fa040f47",
+									"output_index": 1,
+									"delta":        "\"Rome\"",
+								},
+							},
+							{
+								Data: map[string]any{
+									"type":         "response.function_call_arguments.delta",
+									"item_id":      "fc_67cb13a858f081908a600343fa040f47",
+									"output_index": 1,
+									"delta":        "\"}\"",
+								},
+							},
+							{
+								Data: map[string]any{
+									"type":         "response.function_call_arguments.done",
+									"item_id":      "fc_67cb13a858f081908a600343fa040f47",
+									"output_index": 1,
+									"arguments":    "{\"location\":\"Rome\"}",
+								},
+							},
+							{
+								Data: map[string]any{
+									"type":         "response.output_item.done",
+									"output_index": 1,
+									"item": map[string]any{
+										"type":      "function_call",
+										"id":        "fc_67cb13a858f081908a600343fa040f47",
+										"call_id":   "call_X2PAkDJInno9VVnNkDrfhboW",
+										"name":      "weather",
+										"arguments": "{\"location\":\"Rome\"}",
+										"status":    "completed",
+									},
+								},
+							},
+							{
+								Data: map[string]any{
+									"type": "response.completed",
+									"response": map[string]any{
+										"id":         "resp_67cb13a755c08190acbe3839a49632fc",
+										"object":     "response",
+										"created_at": 1741362087,
+										"status":     "completed",
+										"model":      "gpt-4o-2024-07-18",
+										"output": []any{
+											map[string]any{
+												"type":      "function_call",
+												"id":        "fc_67cb13a838088190be08eb3927c87501",
+												"call_id":   "call_KsVqaVAf3alAtCCkQe4itE7W",
+												"name":      "currentLocation",
+												"arguments": "{}",
+												"status":    "completed",
+											},
+											map[string]any{
+												"type":      "function_call",
+												"id":        "fc_67cb13a858f081908a600343fa040f47",
+												"call_id":   "call_X2PAkDJInno9VVnNkDrfhboW",
+												"name":      "weather",
+												"arguments": "{\"location\":\"Rome\"}",
+												"status":    "completed",
+											},
+										},
+									},
+								},
+							},
+						}),
+					},
+				},
+			},
+			expectedEvents: []api.StreamEvent{
+				&api.ResponseMetadataEvent{
+					ID:        "resp_67cb13a755c08190acbe3839a49632fc",
+					ModelID:   "gpt-4o-2024-07-18",
+					Timestamp: pointer.Ptr(time.Date(2025, 3, 7, 15, 41, 27, 0, time.UTC)),
+				},
+				&api.ToolCallDeltaEvent{
+					ToolCallID:   "call_6KxSghkb4MVnunFH2TxPErLP",
+					ToolName:     "currentLocation",
+					ToolCallType: "function",
+					ArgsDelta:    []byte(""),
+				},
+				&api.ToolCallDeltaEvent{
+					ToolCallID:   "call_6KxSghkb4MVnunFH2TxPErLP",
+					ToolName:     "currentLocation",
+					ToolCallType: "function",
+					ArgsDelta:    []byte("{}"),
+				},
+				&api.ToolCallEvent{
+					ToolCallID: "call_pgjcAI4ZegMkP6bsAV7sfrJA",
+					ToolName:   "currentLocation",
+					Args:       json.RawMessage(`{}`),
+				},
+				&api.ToolCallDeltaEvent{
+					ToolCallID:   "call_Dg6WUmFHNeR5JxX1s53s1G4b",
+					ToolName:     "weather",
+					ToolCallType: "function",
+					ArgsDelta:    []byte(""),
+				},
+				&api.ToolCallDeltaEvent{
+					ToolCallID:   "call_Dg6WUmFHNeR5JxX1s53s1G4b",
+					ToolName:     "weather",
+					ToolCallType: "function",
+					ArgsDelta:    []byte("{"),
+				},
+				&api.ToolCallDeltaEvent{
+					ToolCallID:   "call_Dg6WUmFHNeR5JxX1s53s1G4b",
+					ToolName:     "weather",
+					ToolCallType: "function",
+					ArgsDelta:    []byte("\"location\""),
+				},
+				&api.ToolCallDeltaEvent{
+					ToolCallID:   "call_Dg6WUmFHNeR5JxX1s53s1G4b",
+					ToolName:     "weather",
+					ToolCallType: "function",
+					ArgsDelta:    []byte("\":\""),
+				},
+				&api.ToolCallDeltaEvent{
+					ToolCallID:   "call_Dg6WUmFHNeR5JxX1s53s1G4b",
+					ToolName:     "weather",
+					ToolCallType: "function",
+					ArgsDelta:    []byte("\"Rome\""),
+				},
+				&api.ToolCallDeltaEvent{
+					ToolCallID:   "call_Dg6WUmFHNeR5JxX1s53s1G4b",
+					ToolName:     "weather",
+					ToolCallType: "function",
+					ArgsDelta:    []byte("\"}\""),
+				},
+				&api.ToolCallEvent{
+					ToolCallID: "call_X2PAkDJInno9VVnNkDrfhboW",
+					ToolName:   "weather",
+					Args:       json.RawMessage(`{"location":"Rome"}`),
+				},
+				&api.FinishEvent{
+					FinishReason: api.FinishReasonToolCalls,
+					Usage: &api.Usage{
+						PromptTokens:     0,
+						CompletionTokens: 0,
+					},
+					ProviderMetadata: api.NewProviderMetadata(map[string]any{
+						"openai": &Metadata{
+							ResponseID: "resp_67cb13a755c08190acbe3839a49632fc",
+							Usage:      codec.Usage{},
+						},
+					}),
+				},
+			},
+		},
+		{
+			name:    "should_stream_sources",
+			modelID: "gpt-4o-mini",
+			prompt:  standardPrompt,
+			options: api.CallOptions{
+				Mode: api.RegularMode{
+					Tools: []api.ToolDefinition{
+						&codec.WebSearchTool{
+							SearchContextSize: "medium",
+							UserLocation: &codec.WebSearchUserLocation{
+								Country: "US",
+							},
+						},
+					},
+				},
+			},
+			exchanges: []httpmock.Exchange{
+				{
+					Request: httpmock.Request{
+						Method: http.MethodPost,
+						Path:   "/responses",
+					},
+					Response: httpmock.Response{
+						StatusCode: http.StatusOK,
+						Headers: map[string]string{
+							"Content-Type": "text/event-stream",
+						},
+						Body: eventsToString([]sse.Event{
+							{
+								Data: map[string]any{
+									"type": "response.created",
+									"response": map[string]any{
+										"id":         "resp_67cf3390786881908b27489d7e8cfb6b",
+										"object":     "response",
+										"created_at": 1741632400,
+										"status":     "in_progress",
+										"model":      "gpt-4o-mini-2024-07-18",
+										"tools": []any{
+											map[string]any{
+												"type":                "web_search_preview",
+												"search_context_size": "medium",
+												"user_location": map[string]any{
+													"type":     "approximate",
+													"city":     nil,
+													"country":  "US",
+													"region":   nil,
+													"timezone": nil,
+												},
+											},
+										},
+									},
+								},
+							},
+							{
+								Data: map[string]any{
+									"type": "response.in_progress",
+									"response": map[string]any{
+										"id":         "resp_67cf3390786881908b27489d7e8cfb6b",
+										"object":     "response",
+										"created_at": 1741632400,
+										"status":     "in_progress",
+										"model":      "gpt-4o-mini-2024-07-18",
+										"tools": []any{
+											map[string]any{
+												"type":                "web_search_preview",
+												"search_context_size": "medium",
+												"user_location": map[string]any{
+													"type":     "approximate",
+													"city":     nil,
+													"country":  "US",
+													"region":   nil,
+													"timezone": nil,
+												},
+											},
+										},
+									},
+								},
+							},
+							{
+								Data: map[string]any{
+									"type":         "response.output_item.added",
+									"output_index": 0,
+									"item": map[string]any{
+										"type":   "web_search_call",
+										"id":     "ws_67cf3390e9608190869b5d45698a7067",
+										"status": "in_progress",
+									},
+								},
+							},
+							{
+								Data: map[string]any{
+									"type":         "response.web_search_call.in_progress",
+									"output_index": 0,
+									"item_id":      "ws_67cf3390e9608190869b5d45698a7067",
+								},
+							},
+							{
+								Data: map[string]any{
+									"type":         "response.web_search_call.searching",
+									"output_index": 0,
+									"item_id":      "ws_67cf3390e9608190869b5d45698a7067",
+								},
+							},
+							{
+								Data: map[string]any{
+									"type":         "response.web_search_call.completed",
+									"output_index": 0,
+									"item_id":      "ws_67cf3390e9608190869b5d45698a7067",
+								},
+							},
+							{
+								Data: map[string]any{
+									"type":         "response.output_item.done",
+									"output_index": 0,
+									"item": map[string]any{
+										"type":   "web_search_call",
+										"id":     "ws_67cf3390e9608190869b5d45698a7067",
+										"status": "completed",
+									},
+								},
+							},
+							{
+								Data: map[string]any{
+									"type":         "response.output_item.added",
+									"output_index": 1,
+									"item": map[string]any{
+										"type":    "message",
+										"id":      "msg_67cf33924ea88190b8c12bf68c1f6416",
+										"status":  "in_progress",
+										"role":    "assistant",
+										"content": []any{},
+									},
+								},
+							},
+							{
+								Data: map[string]any{
+									"type":          "response.content_part.added",
+									"item_id":       "msg_67cf33924ea88190b8c12bf68c1f6416",
+									"output_index":  1,
+									"content_index": 0,
+									"part": map[string]any{
+										"type":        "output_text",
+										"text":        "",
+										"annotations": []any{},
+									},
+								},
+							},
+							{
+								Data: map[string]any{
+									"type":          "response.output_text.delta",
+									"item_id":       "msg_67cf33924ea88190b8c12bf68c1f6416",
+									"output_index":  1,
+									"content_index": 0,
+									"delta":         "Last week",
+								},
+							},
+							{
+								Data: map[string]any{
+									"type":          "response.output_text.delta",
+									"item_id":       "msg_67cf33924ea88190b8c12bf68c1f6416",
+									"output_index":  1,
+									"content_index": 0,
+									"delta":         " in San Francisco",
+								},
+							},
+							{
+								Data: map[string]any{
+									"type":             "response.output_text.annotation.added",
+									"item_id":          "msg_67cf33924ea88190b8c12bf68c1f6416",
+									"output_index":     1,
+									"content_index":    0,
+									"annotation_index": 0,
+									"annotation": map[string]any{
+										"type":        "url_citation",
+										"start_index": 383,
+										"end_index":   493,
+										"url":         "https://www.sftourismtips.com/san-francisco-events-in-march.html?utm_source=chatgpt.com",
+										"title":       "San Francisco Events in March 2025: Festivals, Theater & Easter",
+									},
+								},
+							},
+							{
+								Data: map[string]any{
+									"type":          "response.output_text.delta",
+									"item_id":       "msg_67cf33924ea88190b8c12bf68c1f6416",
+									"output_index":  1,
+									"content_index": 0,
+									"delta":         " a themed party",
+								},
+							},
+							{
+								Data: map[string]any{
+									"type":          "response.output_text.delta",
+									"item_id":       "msg_67cf33924ea88190b8c12bf68c1f6416",
+									"output_index":  1,
+									"content_index": 0,
+									"delta":         "([axios.com](https://www.axios.com/local/san-francisco/2025/03/06/sf-events-march-what-to-do-giants-fanfest?utm_source=chatgpt.com))",
+								},
+							},
+							{
+								Data: map[string]any{
+									"type":             "response.output_text.annotation.added",
+									"item_id":          "msg_67cf33924ea88190b8c12bf68c1f6416",
+									"output_index":     1,
+									"content_index":    0,
+									"annotation_index": 1,
+									"annotation": map[string]any{
+										"type":        "url_citation",
+										"start_index": 630,
+										"end_index":   762,
+										"url":         "https://www.axios.com/local/san-francisco/2025/03/06/sf-events-march-what-to-do-giants-fanfest?utm_source=chatgpt.com",
+										"title":       "SF weekend events: Giants FanFest, crab crawl and more",
+									},
+								},
+							},
+							{
+								Data: map[string]any{
+									"type":          "response.output_text.delta",
+									"item_id":       "msg_67cf33924ea88190b8c12bf68c1f6416",
+									"output_index":  1,
+									"content_index": 0,
+									"delta":         ".",
+								},
+							},
+							{
+								Data: map[string]any{
+									"type":          "response.output_text.done",
+									"item_id":       "msg_67cf33924ea88190b8c12bf68c1f6416",
+									"output_index":  1,
+									"content_index": 0,
+									"text":          "Last week in San Francisco a themed party...",
+								},
+							},
+							{
+								Data: map[string]any{
+									"type":          "response.content_part.done",
+									"item_id":       "msg_67cf33924ea88190b8c12bf68c1f6416",
+									"output_index":  1,
+									"content_index": 0,
+									"part": map[string]any{
+										"type": "output_text",
+										"text": "Last week in San Francisco a themed party...",
+										"annotations": []any{
+											map[string]any{
+												"type":        "url_citation",
+												"start_index": 383,
+												"end_index":   493,
+												"url":         "https://www.sftourismtips.com/san-francisco-events-in-march.html?utm_source=chatgpt.com",
+												"title":       "San Francisco Events in March 2025: Festivals, Theater & Easter",
+											},
+											map[string]any{
+												"type":        "url_citation",
+												"start_index": 630,
+												"end_index":   762,
+												"url":         "https://www.axios.com/local/san-francisco/2025/03/06/sf-events-march-what-to-do-giants-fanfest?utm_source=chatgpt.com",
+												"title":       "SF weekend events: Giants FanFest, crab crawl and more",
+											},
+										},
+									},
+								},
+							},
+							{
+								Data: map[string]any{
+									"type":         "response.output_item.done",
+									"output_index": 1,
+									"item": map[string]any{
+										"type":   "message",
+										"id":     "msg_67cf33924ea88190b8c12bf68c1f6416",
+										"status": "completed",
+										"role":   "assistant",
+										"content": []any{
+											map[string]any{
+												"type": "output_text",
+												"text": "Last week in San Francisco a themed party...",
+												"annotations": []any{
+													map[string]any{
+														"type":        "url_citation",
+														"start_index": 383,
+														"end_index":   493,
+														"url":         "https://www.sftourismtips.com/san-francisco-events-in-march.html?utm_source=chatgpt.com",
+														"title":       "San Francisco Events in March 2025: Festivals, Theater & Easter",
+													},
+													map[string]any{
+														"type":        "url_citation",
+														"start_index": 630,
+														"end_index":   762,
+														"url":         "https://www.axios.com/local/san-francisco/2025/03/06/sf-events-march-what-to-do-giants-fanfest?utm_source=chatgpt.com",
+														"title":       "SF weekend events: Giants FanFest, crab crawl and more",
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							{
+								Data: map[string]any{
+									"type": "response.completed",
+									"response": map[string]any{
+										"id":         "resp_67cf3390786881908b27489d7e8cfb6b",
+										"object":     "response",
+										"created_at": 1741632400,
+										"status":     "completed",
+										"model":      "gpt-4o-mini-2024-07-18",
+										"output": []any{
+											map[string]any{
+												"type":   "web_search_call",
+												"id":     "ws_67cf3390e9608190869b5d45698a7067",
+												"status": "completed",
+											},
+											map[string]any{
+												"type":   "message",
+												"id":     "msg_67cf33924ea88190b8c12bf68c1f6416",
+												"status": "completed",
+												"role":   "assistant",
+												"content": []any{
+													map[string]any{
+														"type": "output_text",
+														"text": "Last week in San Francisco a themed party...",
+														"annotations": []any{
+															map[string]any{
+																"type":        "url_citation",
+																"start_index": 383,
+																"end_index":   493,
+																"url":         "https://www.sftourismtips.com/san-francisco-events-in-march.html?utm_source=chatgpt.com",
+																"title":       "San Francisco Events in March 2025: Festivals, Theater & Easter",
+															},
+															map[string]any{
+																"type":        "url_citation",
+																"start_index": 630,
+																"end_index":   762,
+																"url":         "https://www.axios.com/local/san-francisco/2025/03/06/sf-events-march-what-to-do-giants-fanfest?utm_source=chatgpt.com",
+																"title":       "SF weekend events: Giants FanFest, crab crawl and more",
+															},
+														},
+													},
+												},
+											},
+										},
+										"usage": map[string]any{
+											"input_tokens": 327,
+											"input_tokens_details": map[string]any{
+												"cached_tokens": 0,
+											},
+											"output_tokens": 834,
+											"output_tokens_details": map[string]any{
+												"reasoning_tokens": 0,
+											},
+											"total_tokens": 1161,
+										},
+									},
+								},
+							},
+						}),
+					},
+				},
+			},
+			expectedEvents: []api.StreamEvent{
+				&api.ResponseMetadataEvent{
+					ID:        "resp_67cf3390786881908b27489d7e8cfb6b",
+					ModelID:   "gpt-4o-mini-2024-07-18",
+					Timestamp: pointer.Ptr(time.Date(2025, 3, 10, 18, 46, 40, 0, time.UTC)),
+				},
+				&api.TextDeltaEvent{
+					TextDelta: "Last week",
+				},
+				&api.TextDeltaEvent{
+					TextDelta: " in San Francisco",
+				},
+				&api.SourceEvent{
+					Source: api.Source{
+						ID:         "source-0",
+						SourceType: "url",
+						Title:      "San Francisco Events in March 2025: Festivals, Theater & Easter",
+						URL:        "https://www.sftourismtips.com/san-francisco-events-in-march.html?utm_source=chatgpt.com",
+					},
+				},
+				&api.TextDeltaEvent{
+					TextDelta: " a themed party",
+				},
+				&api.TextDeltaEvent{
+					TextDelta: "([axios.com](https://www.axios.com/local/san-francisco/2025/03/06/sf-events-march-what-to-do-giants-fanfest?utm_source=chatgpt.com))",
+				},
+				&api.SourceEvent{
+					Source: api.Source{
+						ID:         "source-1",
+						SourceType: "url",
+						Title:      "SF weekend events: Giants FanFest, crab crawl and more",
+						URL:        "https://www.axios.com/local/san-francisco/2025/03/06/sf-events-march-what-to-do-giants-fanfest?utm_source=chatgpt.com",
+					},
+				},
+				&api.TextDeltaEvent{
+					TextDelta: ".",
+				},
+				&api.FinishEvent{
+					FinishReason: api.FinishReasonStop,
+					Usage: &api.Usage{
+						PromptTokens:     327,
+						CompletionTokens: 834,
+					},
+					ProviderMetadata: api.NewProviderMetadata(map[string]any{
+						"openai": &Metadata{
+							ResponseID: "resp_67cf3390786881908b27489d7e8cfb6b",
+							Usage: codec.Usage{
+								InputTokens:           327,
+								OutputTokens:          834,
+								InputCachedTokens:     0,
+								OutputReasoningTokens: 0,
+							},
+						},
+					}),
+				},
+			},
+		},
+		{
+			name:    "should stream reasoning summary",
+			modelID: "o3-mini-2025-01-31",
+			prompt:  standardPrompt,
+			options: api.CallOptions{
+				ProviderMetadata: api.NewProviderMetadata(map[string]any{
+					"openai": &Metadata{
+						ReasoningEffort:  "low",
+						ReasoningSummary: "auto",
+					},
+				}),
+			},
+			exchanges: []httpmock.Exchange{
+				{
+					Request: httpmock.Request{
+						Method: http.MethodPost,
+						Path:   "/responses",
+						Body: `{
+							"model": "o3-mini-2025-01-31",
+							"input": [
+								{
+									"role": "user",
+									"content": [
+										{
+											"type": "input_text",
+											"text": "Hello"
+										}
+									]
+								}
+							],
+							"reasoning": {
+								"effort": "low",
+								"summary": "auto"
+							},
+							"stream": true
+						}`,
+					},
+					Response: httpmock.Response{
+						StatusCode: http.StatusOK,
+						Headers: map[string]string{
+							"Content-Type": "text/event-stream",
+						},
+						Body: eventsToString([]sse.Event{
+							{
+								Data: map[string]any{
+									"type": "response.created",
+									"response": map[string]any{
+										"id":         "resp_67c9a81b6a048190a9ee441c5755a4e8",
+										"object":     "response",
+										"created_at": 1741269019,
+										"status":     "in_progress",
+										"model":      "o3-mini-2025-01-31",
+										"reasoning":  map[string]any{"effort": "low", "summary": "auto"},
+									},
+								},
+							},
+							{Data: map[string]any{"type": "response.reasoning_summary_text.delta", "item_id": "rs_68082c0556348191af675cee0453109b", "output_index": 0, "summary_index": 0, "delta": "**Exploring burrito origins**\n\nThe user is"}},
+							{Data: map[string]any{"type": "response.reasoning_summary_text.delta", "item_id": "rs_68082c0556348191af675cee0453109b", "output_index": 0, "summary_index": 0, "delta": " curious about the debate regarding Taqueria La Cumbre and El Farolito."}},
+							{Data: map[string]any{"type": "response.reasoning_summary_text.done", "item_id": "rs_68082c0556348191af675cee0453109b", "output_index": 0, "summary_index": 0, "text": "**Exploring burrito origins**\n\nThe user is curious about the debate regarding Taqueria La Cumbre and El Farolito."}},
+							{Data: map[string]any{"type": "response.reasoning_summary_text.delta", "item_id": "rs_68082c0556348191af675cee0453109b", "output_index": 0, "summary_index": 1, "delta": "**Investigating burrito origins**\n\nThere's a fascinating debate about who created the Mission burrito."}},
+							{Data: map[string]any{"type": "response.reasoning_summary_part.done", "item_id": "rs_68082c0556348191af675cee0453109b", "output_index": 0, "summary_index": 1, "part": map[string]any{"type": "summary_text", "text": "**Investigating burrito origins**\n\nThere's a fascinating debate about who created the Mission burrito."}}},
+							{Data: map[string]any{"type": "response.output_item.added", "output_index": 1, "item": map[string]any{"id": "msg_67c9a81dea8c8190b79651a2b3adf91e", "type": "message", "status": "in_progress", "role": "assistant", "content": []any{}}}},
+							{Data: map[string]any{"type": "response.content_part.added", "item_id": "msg_67c9a81dea8c8190b79651a2b3adf91e", "output_index": 1, "content_index": 0, "part": map[string]any{"type": "output_text", "text": "", "annotations": []any{}}}},
+							{Data: map[string]any{"type": "response.output_text.delta", "item_id": "msg_67c9a81dea8c8190b79651a2b3adf91e", "output_index": 1, "content_index": 0, "delta": "Taqueria La Cumbre"}},
+							{
+								Data: map[string]any{
+									"type": "response.completed",
+									"response": map[string]any{
+										"id":         "resp_67c9a81b6a048190a9ee441c5755a4e8",
+										"object":     "response",
+										"created_at": 1741269019,
+										"status":     "completed",
+										"model":      "o3-mini-2025-01-31",
+										"output": []any{
+											map[string]any{
+												"id": "rs_68082c0556348191af675cee0453109b", "type": "reasoning",
+												"summary": []any{
+													map[string]any{"type": "summary_text", "text": "**Exploring burrito origins**\n\nThe user is curious about the debate regarding Taqueria La Cumbre and El Farolito."},
+													map[string]any{"type": "summary_text", "text": "**Investigating burrito origins**\n\nThere's a fascinating debate about who created the Mission burrito."},
+												},
+											},
+											map[string]any{
+												"id": "msg_67c9a81dea8c8190b79651a2b3adf91e", "type": "message", "status": "completed", "role": "assistant",
+												"content": []any{map[string]any{"type": "output_text", "text": "Taqueria La Cumbre", "annotations": []any{}}},
+											},
+										},
+										"reasoning": map[string]any{"effort": "low", "summary": "auto"},
+										"usage": map[string]any{
+											"input_tokens":          543,
+											"input_tokens_details":  map[string]any{"cached_tokens": 234},
+											"output_tokens":         478,
+											"output_tokens_details": map[string]any{"reasoning_tokens": 350},
+											"total_tokens":          1021,
+										},
+									},
+								},
+							},
+						}),
+					},
+				},
+			},
+			expectedEvents: []api.StreamEvent{
+				&api.ResponseMetadataEvent{
+					ID:        "resp_67c9a81b6a048190a9ee441c5755a4e8",
+					ModelID:   "o3-mini-2025-01-31",
+					Timestamp: pointer.Ptr(time.Date(2025, 3, 6, 13, 50, 19, 0, time.UTC)),
+				},
+				&api.ReasoningEvent{
+					TextDelta: "**Exploring burrito origins**\n\nThe user is",
+				},
+				&api.ReasoningEvent{
+					TextDelta: " curious about the debate regarding Taqueria La Cumbre and El Farolito.",
+				},
+				&api.ReasoningEvent{
+					TextDelta: "**Investigating burrito origins**\n\nThere's a fascinating debate about who created the Mission burrito.",
+				},
+				&api.TextDeltaEvent{
+					TextDelta: "Taqueria La Cumbre",
+				},
+				&api.FinishEvent{
+					FinishReason: api.FinishReasonStop,
+					Usage: &api.Usage{
+						PromptTokens:     543,
+						CompletionTokens: 478,
+					},
+					ProviderMetadata: api.NewProviderMetadata(map[string]any{
+						"openai": &Metadata{
+							ResponseID: "resp_67c9a81b6a048190a9ee441c5755a4e8",
+							Usage: codec.Usage{
+								InputTokens:           543,
+								OutputTokens:          478,
+								InputCachedTokens:     234,
+								OutputReasoningTokens: 350,
+							},
+						},
+					}),
+				},
+			},
+		},
+	}
+
+	runStreamTests(t, tests)
 }
 
 func runGenerateTests(t *testing.T, tests []struct {
@@ -1669,6 +2965,64 @@ func runGenerateTests(t *testing.T, tests []struct {
 
 			// Use aitesting.ResponseContains to verify expected response fields
 			aitesting.ResponseContains(t, tt.expectedResp, resp)
+		})
+	}
+}
+
+func runStreamTests(t *testing.T, tests []struct {
+	name           string
+	modelID        string
+	options        api.CallOptions
+	prompt         []api.Message
+	exchanges      []httpmock.Exchange
+	wantErr        bool
+	expectedEvents []api.StreamEvent
+	skip           bool
+}) {
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.skip {
+				t.Skipf("Skipping test: %s", tt.name)
+			}
+
+			server := httpmock.NewServer(t, tt.exchanges)
+			defer server.Close()
+
+			// Set up client options for the OpenAI client
+			clientOptions := []option.RequestOption{
+				option.WithBaseURL(server.BaseURL()),
+				option.WithAPIKey("test-key"),
+				option.WithMaxRetries(0), // Disable retries
+			}
+
+			// Create client with options
+			client := openai.NewClient(clientOptions...)
+
+			// Use custom model ID
+			modelID := tt.modelID
+
+			// Create model with mocked client
+			model := NewLanguageModel(modelID, WithClient(client))
+
+			// Call Stream with the test's options (or empty if not specified)
+			resp, err := model.Stream(t.Context(), tt.prompt, tt.options)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+
+			// Collect all events from the stream
+			var gotEvents []api.StreamEvent
+			for event := range resp.Events {
+				gotEvents = append(gotEvents, event)
+			}
+
+			// Compare events using deep equality
+			require.Equal(t, tt.expectedEvents, gotEvents)
 		})
 	}
 }


### PR DESCRIPTION
## Summary
Implements streaming support in the OpenAI provider.

- Add a Stream method in llm.go that encodes parameters and decodes an OpenAI SSE stream
- Refactor encode.go to clean up metadata handling and reasoning settings
- Introduce decode_stream.go with full event-by-event decoding plus corresponding tests

## How was it tested?
Unit tests.

## Community Contribution License

All community contributions in this pull request are licensed to the project maintainers under the terms of the [Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request I represent that I have the right to license the contributions to the project maintainers under the Apache 2 License as stated in the [Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).
