### PR TITLE
[AI] Refactor Response struct to have a single Content field

### DIFF
--- a/aisdk/ai/aitesting/aitesting_test.go
+++ b/aisdk/ai/aitesting/aitesting_test.go
@@ -37,20 +37,28 @@ func TestResponseContains(t *testing.T) {
 		{
 			name: "matching text",
 			expected: api.Response{
-				Text: "hello world",
+				Content: []api.ContentBlock{
+					&api.TextBlock{Text: "hello world"},
+				},
 			},
 			contains: api.Response{
-				Text: "hello world",
+				Content: []api.ContentBlock{
+					&api.TextBlock{Text: "hello world"},
+				},
 			},
 			wantFail: false,
 		},
 		{
 			name: "mismatched text",
 			expected: api.Response{
-				Text: "hello world",
+				Content: []api.ContentBlock{
+					&api.TextBlock{Text: "hello world"},
+				},
 			},
 			contains: api.Response{
-				Text: "goodbye world",
+				Content: []api.ContentBlock{
+					&api.TextBlock{Text: "goodbye world"},
+				},
 			},
 			wantFail: true,
 		},
@@ -140,23 +148,26 @@ func TestResponseContains(t *testing.T) {
 		{
 			name: "ignores unset fields",
 			expected: api.Response{
-				Text: "hello",
+				Content: []api.ContentBlock{
+					&api.TextBlock{Text: "hello"},
+				},
 			},
 			contains: api.Response{
-				Text: "hello",
+				Content: []api.ContentBlock{
+					&api.TextBlock{Text: "hello"},
+					&api.SourceBlock{ID: "src-1", URL: "http://example.com"},
+				},
 				ResponseInfo: &api.ResponseInfo{
 					ModelID: "different-model",
 				},
-				Sources:  []api.Source{},
-				LogProbs: api.LogProbs{},
 			},
 			wantFail: false,
 		},
 		{
 			name: "matching tool calls",
 			expected: api.Response{
-				ToolCalls: []api.ToolCallBlock{
-					{
+				Content: []api.ContentBlock{
+					&api.ToolCallBlock{
 						ToolCallID: "test-id",
 						ToolName:   "test",
 						Args:       json.RawMessage(`"args"`),
@@ -164,8 +175,8 @@ func TestResponseContains(t *testing.T) {
 				},
 			},
 			contains: api.Response{
-				ToolCalls: []api.ToolCallBlock{
-					{
+				Content: []api.ContentBlock{
+					&api.ToolCallBlock{
 						ToolCallID: "test-id",
 						ToolName:   "test",
 						Args:       json.RawMessage(`"args"`),
@@ -177,8 +188,8 @@ func TestResponseContains(t *testing.T) {
 		{
 			name: "matching files",
 			expected: api.Response{
-				Files: []api.FileBlock{
-					{
+				Content: []api.ContentBlock{
+					&api.FileBlock{
 						Filename:  "test.txt",
 						Data:      []byte("test content"),
 						MediaType: "text/plain",
@@ -186,8 +197,8 @@ func TestResponseContains(t *testing.T) {
 				},
 			},
 			contains: api.Response{
-				Files: []api.FileBlock{
-					{
+				Content: []api.ContentBlock{
+					&api.FileBlock{
 						Filename:  "test.txt",
 						Data:      []byte("test content"),
 						MediaType: "text/plain",
@@ -199,8 +210,8 @@ func TestResponseContains(t *testing.T) {
 		{
 			name: "mismatched files",
 			expected: api.Response{
-				Files: []api.FileBlock{
-					{
+				Content: []api.ContentBlock{
+					&api.FileBlock{
 						Filename:  "test.txt",
 						Data:      []byte("test content"),
 						MediaType: "text/plain",
@@ -208,8 +219,8 @@ func TestResponseContains(t *testing.T) {
 				},
 			},
 			contains: api.Response{
-				Files: []api.FileBlock{
-					{
+				Content: []api.ContentBlock{
+					&api.FileBlock{
 						Filename:  "different.txt",
 						Data:      []byte("different content"),
 						MediaType: "text/plain",
@@ -217,6 +228,189 @@ func TestResponseContains(t *testing.T) {
 				},
 			},
 			wantFail: true,
+		},
+		{
+			name: "matching image blocks",
+			expected: api.Response{
+				Content: []api.ContentBlock{
+					&api.ImageBlock{
+						URL:       "https://example.com/image.jpg",
+						MediaType: "image/jpeg",
+					},
+				},
+			},
+			contains: api.Response{
+				Content: []api.ContentBlock{
+					&api.ImageBlock{
+						URL:       "https://example.com/image.jpg",
+						MediaType: "image/jpeg",
+					},
+				},
+			},
+			wantFail: false,
+		},
+		{
+			name: "matching reasoning blocks",
+			expected: api.Response{
+				Content: []api.ContentBlock{
+					&api.ReasoningBlock{
+						Text:      "Let me think about this...",
+						Signature: "sig123",
+					},
+				},
+			},
+			contains: api.Response{
+				Content: []api.ContentBlock{
+					&api.ReasoningBlock{
+						Text:      "Let me think about this...",
+						Signature: "sig123",
+					},
+				},
+			},
+			wantFail: false,
+		},
+		{
+			name: "matching redacted reasoning blocks",
+			expected: api.Response{
+				Content: []api.ContentBlock{
+					&api.RedactedReasoningBlock{
+						Data: "redacted_data_123",
+					},
+				},
+			},
+			contains: api.Response{
+				Content: []api.ContentBlock{
+					&api.RedactedReasoningBlock{
+						Data: "redacted_data_123",
+					},
+				},
+			},
+			wantFail: false,
+		},
+		{
+			name: "matching source blocks",
+			expected: api.Response{
+				Content: []api.ContentBlock{
+					&api.SourceBlock{
+						ID:    "src-1",
+						URL:   "https://example.com",
+						Title: "Example Source",
+					},
+				},
+			},
+			contains: api.Response{
+				Content: []api.ContentBlock{
+					&api.SourceBlock{
+						ID:    "src-1",
+						URL:   "https://example.com",
+						Title: "Example Source",
+					},
+				},
+			},
+			wantFail: false,
+		},
+		{
+			name: "partial field matching - tool call only name",
+			expected: api.Response{
+				Content: []api.ContentBlock{
+					&api.ToolCallBlock{
+						ToolName: "test",
+						// ID and Args are not set, so they won't be compared
+					},
+				},
+			},
+			contains: api.Response{
+				Content: []api.ContentBlock{
+					&api.ToolCallBlock{
+						ToolCallID: "some-id",
+						ToolName:   "test",
+						Args:       json.RawMessage(`{"key": "value"}`),
+					},
+				},
+			},
+			wantFail: false,
+		},
+		{
+			name: "partial field matching - text block empty text",
+			expected: api.Response{
+				Content: []api.ContentBlock{
+					&api.TextBlock{
+						// Text is empty, so it won't be compared
+					},
+				},
+			},
+			contains: api.Response{
+				Content: []api.ContentBlock{
+					&api.TextBlock{
+						Text: "any text here",
+					},
+				},
+			},
+			wantFail: false,
+		},
+		{
+			name: "mixed content blocks",
+			expected: api.Response{
+				Content: []api.ContentBlock{
+					&api.TextBlock{Text: "hello"},
+					&api.ToolCallBlock{ToolName: "test"},
+				},
+			},
+			contains: api.Response{
+				Content: []api.ContentBlock{
+					&api.TextBlock{Text: "hello"},
+					&api.ImageBlock{URL: "https://example.com/img.jpg"},
+					&api.ToolCallBlock{
+						ToolCallID: "id-123",
+						ToolName:   "test",
+						Args:       json.RawMessage(`{}`),
+					},
+					&api.SourceBlock{ID: "src-1"},
+				},
+			},
+			wantFail: true,
+		},
+		{
+			name: "wrong content block type",
+			expected: api.Response{
+				Content: []api.ContentBlock{
+					&api.TextBlock{Text: "hello"},
+				},
+			},
+			contains: api.Response{
+				Content: []api.ContentBlock{
+					&api.ImageBlock{URL: "https://example.com/img.jpg"},
+				},
+			},
+			wantFail: true,
+		},
+		{
+			name: "empty content blocks",
+			expected: api.Response{
+				Content: []api.ContentBlock{},
+			},
+			contains: api.Response{
+				Content: []api.ContentBlock{
+					&api.TextBlock{Text: "hello"},
+				},
+			},
+			wantFail: false,
+		},
+		{
+			name: "content blocks must match in order",
+			expected: api.Response{
+				Content: []api.ContentBlock{
+					&api.TextBlock{Text: "first"},
+					&api.ToolCallBlock{ToolName: "test"},
+				},
+			},
+			contains: api.Response{
+				Content: []api.ContentBlock{
+					&api.ToolCallBlock{ToolName: "test"},
+					&api.TextBlock{Text: "first"},
+				},
+			},
+			wantFail: true, // Should fail because order is wrong
 		},
 	}
 

--- a/aisdk/ai/api/llm_prompt.go
+++ b/aisdk/ai/api/llm_prompt.go
@@ -130,6 +130,8 @@ const (
 	ContentBlockTypeReasoning ContentBlockType = "reasoning"
 	// ContentBlockTypeRedactedReasoning represents redacted reasoning data
 	ContentBlockTypeRedactedReasoning ContentBlockType = "redacted-reasoning"
+	// ContentBlockTypeSource represents a source block
+	ContentBlockTypeSource ContentBlockType = "source"
 )
 
 // ContentBlock represents a block of content in a message
@@ -362,7 +364,7 @@ func (b ToolResultBlock) Type() ContentBlockType { return ContentBlockTypeToolRe
 func (b ToolResultBlock) GetProviderMetadata() *ProviderMetadata { return b.ProviderMetadata }
 
 // SourceBlock represents a source that has been used as input to generate the response.
-type SourceBlock struct { // TODO: output only
+type SourceBlock struct {
 	// ID is the ID of the source.
 	ID string `json:"id"`
 
@@ -375,5 +377,11 @@ type SourceBlock struct { // TODO: output only
 	// ProviderMetadata contains additional provider-specific metadata.
 	// They are passed through to the provider from the AI SDK and enable
 	// provider-specific functionality that can be fully encapsulated in the provider.
-	ProviderMetadata *ProviderMetadata `json:"provider_metadata,omitzero"` // TODO: output
+	ProviderMetadata *ProviderMetadata `json:"provider_metadata,omitzero"`
 }
+
+var _ ContentBlock = &SourceBlock{}
+
+func (b SourceBlock) Type() ContentBlockType { return ContentBlockTypeSource }
+
+func (b SourceBlock) GetProviderMetadata() *ProviderMetadata { return b.ProviderMetadata }

--- a/aisdk/ai/builder/builder.go
+++ b/aisdk/ai/builder/builder.go
@@ -24,10 +24,8 @@ const (
 // you must synchronize access to the builder yourself.
 type ResponseBuilder struct {
 	resp api.Response
-	// Map of tool call ID to index in orderedToolCalls
+	// Map of tool call ID to index in Content array (for parallel tool calls)
 	toolCallIndices map[string]int
-	// Ordered slice of tool calls to maintain order
-	orderedToolCalls []api.ToolCallBlock
 	// Error encountered during event processing
 	err error
 
@@ -43,19 +41,14 @@ type ResponseBuilder struct {
 func NewResponseBuilder() *ResponseBuilder {
 	return &ResponseBuilder{
 		resp: api.Response{
-			// Initialize with empty values
-			Text:         "",
-			Reasoning:    []api.Reasoning{},
-			ToolCalls:    []api.ToolCallBlock{},
-			Sources:      []api.Source{},
+			// Initialize with empty Content slice
+			Content:      []api.ContentBlock{},
 			Warnings:     []api.CallWarning{},
 			FinishReason: api.FinishReason(""),
-			Files:        []api.FileBlock{},
 		},
-		toolCallIndices:  make(map[string]int),
-		orderedToolCalls: make([]api.ToolCallBlock, 0),
-		currentState:     noState,
-		err:              nil,
+		toolCallIndices: make(map[string]int),
+		currentState:    noState,
+		err:             nil,
 	}
 }
 
@@ -105,20 +98,42 @@ func (b *ResponseBuilder) AddEvent(event api.StreamEvent) error {
 
 // addTextDelta adds a text delta event to the response.
 func (b *ResponseBuilder) addTextDelta(e *api.TextDeltaEvent) error {
+	// Only concatenate with last block if the last content block is a TextBlock
+	if len(b.resp.Content) > 0 {
+		if lastBlock, ok := b.resp.Content[len(b.resp.Content)-1].(*api.TextBlock); ok {
+			// Append to existing text block
+			lastBlock.Text += e.TextDelta
+			return nil
+		}
+	}
+
+	// Create new text block
 	b.currentState = textState
-	b.resp.Text += e.TextDelta
+	b.resp.Content = append(b.resp.Content, &api.TextBlock{
+		Text: e.TextDelta,
+	})
 	return nil
 }
 
 // addReasoning adds a reasoning event to the response.
 func (b *ResponseBuilder) addReasoning(e *api.ReasoningEvent) error {
+	// Only concatenate with last block if the last content block is a ReasoningBlock
+	if len(b.resp.Content) > 0 {
+		if lastBlock, ok := b.resp.Content[len(b.resp.Content)-1].(*api.ReasoningBlock); ok {
+			// Append to existing reasoning block
+			lastBlock.Text += e.TextDelta
+			return nil
+		}
+	}
+
 	// Validate state transition
 	if b.currentState != noState && b.currentState != reasoningState {
 		return fmt.Errorf("invalid state transition: cannot add reasoning in state %v", b.currentState)
 	}
 
+	// Create new reasoning block
 	b.currentState = reasoningState
-	b.resp.Reasoning = append(b.resp.Reasoning, &api.ReasoningBlock{
+	b.resp.Content = append(b.resp.Content, &api.ReasoningBlock{
 		Text: e.TextDelta,
 	})
 	return nil
@@ -126,11 +141,11 @@ func (b *ResponseBuilder) addReasoning(e *api.ReasoningEvent) error {
 
 // addReasoningSignature adds a reasoning signature event to the response.
 func (b *ResponseBuilder) addReasoningSignature(e *api.ReasoningSignatureEvent) error {
-	if len(b.resp.Reasoning) == 0 {
-		return fmt.Errorf("cannot add reasoning signature: no reasoning blocks exist")
+	if len(b.resp.Content) == 0 {
+		return fmt.Errorf("cannot add reasoning signature: no content blocks exist")
 	}
 
-	if block, ok := b.resp.Reasoning[len(b.resp.Reasoning)-1].(*api.ReasoningBlock); ok {
+	if block, ok := b.resp.Content[len(b.resp.Content)-1].(*api.ReasoningBlock); ok {
 		block.Signature = e.Signature
 		return nil
 	}
@@ -145,7 +160,7 @@ func (b *ResponseBuilder) addRedactedReasoning(e *api.RedactedReasoningEvent) er
 	}
 
 	b.currentState = reasoningState
-	b.resp.Reasoning = append(b.resp.Reasoning, &api.RedactedReasoningBlock{
+	b.resp.Content = append(b.resp.Content, &api.RedactedReasoningBlock{
 		Data: e.Data,
 	})
 	return nil
@@ -161,13 +176,14 @@ func (b *ResponseBuilder) addToolCall(e *api.ToolCallEvent) error {
 	b.currentState = toolCallState
 
 	// Create new tool call block
-	b.orderedToolCalls = append(b.orderedToolCalls, api.ToolCallBlock{
+	toolCall := &api.ToolCallBlock{
 		ToolCallID: e.ToolCallID,
 		ToolName:   e.ToolName,
 		Args:       slices.Clone(e.Args),
-	})
+	}
+	b.resp.Content = append(b.resp.Content, toolCall)
 	// Store index in the map
-	b.toolCallIndices[e.ToolCallID] = len(b.orderedToolCalls) - 1
+	b.toolCallIndices[e.ToolCallID] = len(b.resp.Content) - 1
 
 	return nil
 }
@@ -180,17 +196,20 @@ func (b *ResponseBuilder) addToolCallDelta(e *api.ToolCallDeltaEvent) error {
 	idx, exists := b.toolCallIndices[e.ToolCallID]
 	if !exists {
 		// Create new tool call block if it doesn't exist
-		b.orderedToolCalls = append(b.orderedToolCalls, api.ToolCallBlock{
+		toolCall := &api.ToolCallBlock{
 			ToolCallID: e.ToolCallID,
 			ToolName:   e.ToolName,
 			Args:       make([]byte, 0),
-		})
-		idx = len(b.orderedToolCalls) - 1
+		}
+		b.resp.Content = append(b.resp.Content, toolCall)
+		idx = len(b.resp.Content) - 1
 		b.toolCallIndices[e.ToolCallID] = idx
 	}
 
 	// Append the new args to the existing args
-	b.orderedToolCalls[idx].Args = append(b.orderedToolCalls[idx].Args, slices.Clone(e.ArgsDelta)...)
+	if toolCall, ok := b.resp.Content[idx].(*api.ToolCallBlock); ok {
+		toolCall.Args = append(toolCall.Args, slices.Clone(e.ArgsDelta)...)
+	}
 
 	return nil
 }
@@ -198,16 +217,19 @@ func (b *ResponseBuilder) addToolCallDelta(e *api.ToolCallDeltaEvent) error {
 // addSource adds a source event to the response.
 func (b *ResponseBuilder) addSource(e *api.SourceEvent) error {
 	b.currentState = sourceState
-	// Create a copy of the source to prevent mutation
-	sourceCopy := e.Source
-	b.resp.Sources = append(b.resp.Sources, sourceCopy)
+	b.resp.Content = append(b.resp.Content, &api.SourceBlock{
+		ID:               e.Source.ID,
+		URL:              e.Source.URL,
+		Title:            e.Source.Title,
+		ProviderMetadata: &e.Source.ProviderMetadata,
+	})
 	return nil
 }
 
 // addFile adds a file event to the response.
 func (b *ResponseBuilder) addFile(e *api.FileEvent) error {
 	b.currentState = fileState
-	b.resp.Files = append(b.resp.Files, api.FileBlock{
+	b.resp.Content = append(b.resp.Content, &api.FileBlock{
 		MediaType: e.MediaType,
 		Data:      slices.Clone(e.Data),
 	})
@@ -260,9 +282,6 @@ func (b *ResponseBuilder) addError(e *api.ErrorEvent) error {
 
 // Build creates a Response from the collected events.
 func (b *ResponseBuilder) Build() (api.Response, error) {
-	// Copy the ordered tool calls to the response
-	b.resp.ToolCalls = slices.Clone(b.orderedToolCalls)
-
 	// Return any error that was encountered during event processing
 	if b.err != nil {
 		return b.resp, b.err
@@ -273,17 +292,12 @@ func (b *ResponseBuilder) Build() (api.Response, error) {
 // AddMetadata adds metadata from a StreamResponse to the builder.
 // It preserves existing non-nil slices in the response.
 func (b *ResponseBuilder) AddMetadata(sr *api.StreamResponse) error {
-	// Only copy warnings if the source has warnings
-	if len(sr.Warnings) > 0 {
-		b.resp.Warnings = sr.Warnings
-	}
-
 	if sr.RequestInfo != nil {
 		b.resp.RequestInfo = sr.RequestInfo
 	}
 
-	if sr.ProviderMetadata != nil {
-		b.resp.ProviderMetadata = sr.ProviderMetadata
+	if sr.ResponseInfo != nil {
+		b.resp.ResponseInfo = sr.ResponseInfo
 	}
 
 	return nil

--- a/aisdk/ai/builder/builder.go
+++ b/aisdk/ai/builder/builder.go
@@ -68,29 +68,54 @@ func (b *ResponseBuilder) AddEvent(event api.StreamEvent) error {
 	// - Validate that we have a model ID if this isn't the first event
 	// The reason we haven't implemented these yet is because I'm not sure if all providers have those guarantees.
 
-	switch e := event.(type) {
+	switch evt := event.(type) {
+	// Handle pointer types
 	case *api.TextDeltaEvent:
-		return b.addTextDelta(e)
+		return b.addTextDelta(evt)
 	case *api.ReasoningEvent:
-		return b.addReasoning(e)
+		return b.addReasoning(evt)
 	case *api.ReasoningSignatureEvent:
-		return b.addReasoningSignature(e)
+		return b.addReasoningSignature(evt)
 	case *api.RedactedReasoningEvent:
-		return b.addRedactedReasoning(e)
+		return b.addRedactedReasoning(evt)
 	case *api.ToolCallEvent:
-		return b.addToolCall(e)
+		return b.addToolCall(evt)
 	case *api.ToolCallDeltaEvent:
-		return b.addToolCallDelta(e)
+		return b.addToolCallDelta(evt)
 	case *api.SourceEvent:
-		return b.addSource(e)
+		return b.addSource(evt)
 	case *api.FileEvent:
-		return b.addFile(e)
+		return b.addFile(evt)
 	case *api.ResponseMetadataEvent:
-		return b.addResponseMetadata(e)
+		return b.addResponseMetadata(evt)
 	case *api.FinishEvent:
-		return b.addFinish(e)
+		return b.addFinish(evt)
 	case *api.ErrorEvent:
-		return b.addError(e)
+		return b.addError(evt)
+
+	// Handle value types
+	case api.TextDeltaEvent:
+		return b.addTextDelta(&evt)
+	case api.ReasoningEvent:
+		return b.addReasoning(&evt)
+	case api.ReasoningSignatureEvent:
+		return b.addReasoningSignature(&evt)
+	case api.RedactedReasoningEvent:
+		return b.addRedactedReasoning(&evt)
+	case api.ToolCallEvent:
+		return b.addToolCall(&evt)
+	case api.ToolCallDeltaEvent:
+		return b.addToolCallDelta(&evt)
+	case api.SourceEvent:
+		return b.addSource(&evt)
+	case api.FileEvent:
+		return b.addFile(&evt)
+	case api.ResponseMetadataEvent:
+		return b.addResponseMetadata(&evt)
+	case api.FinishEvent:
+		return b.addFinish(&evt)
+	case api.ErrorEvent:
+		return b.addError(&evt)
 	default:
 		return fmt.Errorf("unknown event type: %T", event)
 	}

--- a/aisdk/ai/builder/convert.go
+++ b/aisdk/ai/builder/convert.go
@@ -15,7 +15,7 @@ func StreamToResponse(stream *api.StreamResponse) (*api.Response, error) {
 	}
 
 	// Process each event in the stream
-	for event := range stream.Events {
+	for event := range stream.Stream {
 		if err := builder.AddEvent(event); err != nil {
 			return nil, err
 		}

--- a/aisdk/ai/provider/anthropic/codec/decode_test.go
+++ b/aisdk/ai/provider/anthropic/codec/decode_test.go
@@ -231,7 +231,7 @@ func TestDecodeToolUse(t *testing.T) {
 	tests := []struct {
 		name  string
 		block anthropic.BetaContentBlock
-		want  api.ToolCallBlock
+		want  *api.ToolCallBlock
 	}{
 		{
 			name: "block with input",
@@ -241,7 +241,7 @@ func TestDecodeToolUse(t *testing.T) {
 				Type:  anthropic.BetaContentBlockTypeToolUse,
 				Input: json.RawMessage(`{"query":"test"}`),
 			},
-			want: api.ToolCallBlock{
+			want: &api.ToolCallBlock{
 				ToolCallID: "call_123",
 				ToolName:   "search",
 				Args:       json.RawMessage(`{"query":"test"}`),
@@ -254,7 +254,7 @@ func TestDecodeToolUse(t *testing.T) {
 				Name: "get_time",
 				Type: anthropic.BetaContentBlockTypeToolUse,
 			},
-			want: api.ToolCallBlock{
+			want: &api.ToolCallBlock{
 				ToolCallID: "call_456",
 				ToolName:   "get_time",
 				Args:       json.RawMessage(`{}`),
@@ -282,7 +282,7 @@ func TestDecodeToolUseWithMarshalError(t *testing.T) {
 		Input: json.RawMessage(`{malformed json`), // Invalid JSON
 	}
 
-	expected := api.ToolCallBlock{
+	expected := &api.ToolCallBlock{
 		ToolCallID: "call_789",
 		ToolName:   "error_call",
 		Args:       json.RawMessage(`{}`),
@@ -298,7 +298,7 @@ func TestDecodeContent(t *testing.T) {
 	tests := []struct {
 		name   string
 		blocks []anthropic.BetaContentBlock
-		want   responseContent
+		want   []api.ContentBlock
 	}{
 		{
 			name: "multiple block types",
@@ -318,73 +318,56 @@ func TestDecodeContent(t *testing.T) {
 					Input: json.RawMessage(`{"location":"New York"}`),
 				},
 			},
-			want: responseContent{
-				Text: "Hello world",
-				ToolCalls: []api.ToolCallBlock{
-					{
-						ToolCallID: "call_789",
-						ToolName:   "get_weather",
-						Args:       json.RawMessage(`{"location":"New York"}`),
-					},
+			want: []api.ContentBlock{
+				&api.TextBlock{
+					Text: "Hello world",
 				},
-				Reasoning: []api.Reasoning{
-					&api.ReasoningBlock{
-						Text: "Thinking process",
-					},
+				&api.ReasoningBlock{
+					Text: "Thinking process",
+				},
+				&api.ToolCallBlock{
+					ToolCallID: "call_789",
+					ToolName:   "get_weather",
+					Args:       json.RawMessage(`{"location":"New York"}`),
 				},
 			},
 		},
 		{
 			name:   "nil blocks",
 			blocks: nil,
-			want: responseContent{
-				Text:      "",
-				ToolCalls: []api.ToolCallBlock{},
-				Reasoning: []api.Reasoning{},
-			},
+			want:   []api.ContentBlock{},
 		},
 		{
 			name:   "empty blocks",
 			blocks: []anthropic.BetaContentBlock{},
-			want: responseContent{
-				Text:      "",
-				ToolCalls: []api.ToolCallBlock{},
-				Reasoning: []api.Reasoning{},
-			},
+			want:   []api.ContentBlock{},
 		},
 		{
-			name: "empty block type",
+			name: "empty text block should be skipped",
 			blocks: []anthropic.BetaContentBlock{
 				{
-					Type: "",
+					Type: anthropic.BetaContentBlockTypeText,
+					Text: "", // Empty text should be skipped
+				},
+			},
+			want: []api.ContentBlock{},
+		},
+		{
+			name: "unknown block type should be skipped",
+			blocks: []anthropic.BetaContentBlock{
+				{
+					Type: "", // Unknown type
 					Text: "Should be skipped",
 				},
 			},
-			want: responseContent{
-				Text:      "",
-				ToolCalls: []api.ToolCallBlock{},
-				Reasoning: []api.Reasoning{},
-			},
+			want: []api.ContentBlock{},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := decodeContent(tt.blocks)
-			assert.Equal(t, tt.want.Text, got.Text)
-			assert.Equal(t, len(tt.want.ToolCalls), len(got.ToolCalls))
-
-			// Compare tool calls individually to use JSONEq for Args
-			for i, wantToolCall := range tt.want.ToolCalls {
-				if i < len(got.ToolCalls) {
-					gotToolCall := got.ToolCalls[i]
-					assert.Equal(t, wantToolCall.ToolCallID, gotToolCall.ToolCallID)
-					assert.Equal(t, wantToolCall.ToolName, gotToolCall.ToolName)
-					assert.JSONEq(t, string(wantToolCall.Args), string(gotToolCall.Args))
-				}
-			}
-
-			assert.Equal(t, tt.want.Reasoning, got.Reasoning)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -414,7 +397,11 @@ func TestDecodeResponse(t *testing.T) {
 				},
 			},
 			want: api.Response{
-				Text:         "Hello, I am Claude",
+				Content: []api.ContentBlock{
+					&api.TextBlock{
+						Text: "Hello, I am Claude",
+					},
+				},
 				FinishReason: api.FinishReasonStop,
 				Usage: api.Usage{
 					InputTokens:  150,
@@ -433,8 +420,6 @@ func TestDecodeResponse(t *testing.T) {
 						},
 					},
 				}),
-				ToolCalls: []api.ToolCallBlock{},
-				Reasoning: []api.Reasoning{},
 			},
 			wantErr: false,
 		},
@@ -442,6 +427,7 @@ func TestDecodeResponse(t *testing.T) {
 			name: "empty message",
 			msg:  &anthropic.BetaMessage{},
 			want: api.Response{
+				Content:      []api.ContentBlock{},
 				FinishReason: api.FinishReasonUnknown,
 				ResponseInfo: &api.ResponseInfo{},
 				ProviderMetadata: api.NewProviderMetadata(map[string]any{
@@ -449,8 +435,6 @@ func TestDecodeResponse(t *testing.T) {
 						Usage: Usage{},
 					},
 				}),
-				ToolCalls: []api.ToolCallBlock{},
-				Reasoning: []api.Reasoning{},
 			},
 			wantErr: false,
 		},
@@ -470,13 +454,7 @@ func TestDecodeResponse(t *testing.T) {
 				return
 			}
 			assert.NoError(t, err)
-			assert.Equal(t, tt.want.Text, got.Text)
-			assert.Equal(t, tt.want.FinishReason, got.FinishReason)
-			assert.Equal(t, tt.want.Usage, got.Usage)
-			assert.Equal(t, tt.want.ResponseInfo, got.ResponseInfo)
-			assert.Equal(t, tt.want.ProviderMetadata, got.ProviderMetadata)
-			assert.Equal(t, tt.want.ToolCalls, got.ToolCalls)
-			assert.Equal(t, tt.want.Reasoning, got.Reasoning)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/aisdk/ai/provider/internal/openrouter/openrouter_chat_language_model.go
+++ b/aisdk/ai/provider/internal/openrouter/openrouter_chat_language_model.go
@@ -271,23 +271,43 @@ func (m *OpenRouterChatLanguageModel) DoGenerate(
 
 	choice := response.Choices[0]
 
-	// Build result
-	result := api.Response{
-		Text:         stringValue(choice.Message.Content),
-		Reasoning:    convertReasoning(choice.Message.Reasoning),
-		FinishReason: codec.DecodeFinishReason(choice.FinishReason),
+	// Build content blocks
+	var content []api.ContentBlock
+
+	// Add text content if present
+	if choice.Message.Content != nil && *choice.Message.Content != "" {
+		content = append(content, &api.TextBlock{
+			Text: *choice.Message.Content,
+		})
+	}
+
+	// Add reasoning content if present
+	if choice.Message.Reasoning != nil && *choice.Message.Reasoning != "" {
+		content = append(content, &api.ReasoningBlock{
+			Text: *choice.Message.Reasoning,
+		})
 	}
 
 	// Add tool calls if present
 	if len(choice.Message.ToolCalls) > 0 {
-		result.ToolCalls = make([]api.ToolCallBlock, len(choice.Message.ToolCalls))
-		for i, tc := range choice.Message.ToolCalls {
-			result.ToolCalls[i] = api.ToolCallBlock{
+		for _, tc := range choice.Message.ToolCalls {
+			content = append(content, &api.ToolCallBlock{
 				ToolCallID: tc.ID,
 				ToolName:   tc.Function.Name,
 				Args:       json.RawMessage(tc.Function.Arguments),
-			}
+			})
 		}
+	}
+
+	// Build result
+	result := api.Response{
+		Content:      content,
+		FinishReason: codec.DecodeFinishReason(choice.FinishReason),
+		Usage: api.Usage{
+			InputTokens:  response.Usage.PromptTokens,
+			OutputTokens: response.Usage.CompletionTokens,
+			TotalTokens:  response.Usage.PromptTokens + response.Usage.CompletionTokens,
+		},
 	}
 
 	// Add logprobs if present
@@ -331,7 +351,7 @@ func (m *OpenRouterChatLanguageModel) DoStream(
 	}
 
 	// Create sequence for events
-	events := func(yield func(api.StreamEvent) bool) {
+	stream := func(yield func(api.StreamEvent) bool) {
 		defer resp.Body.Close()
 
 		scanner := bufio.NewScanner(resp.Body)
@@ -354,7 +374,7 @@ func (m *OpenRouterChatLanguageModel) DoStream(
 
 			var chunk chatStreamResponse
 			if err := json.Unmarshal([]byte(data), &chunk); err != nil {
-				if !yield(api.ErrorEvent{
+				if !yield(&api.ErrorEvent{
 					Err: api.NewJSONParseError(data, err),
 				}) {
 					return
@@ -372,7 +392,7 @@ func (m *OpenRouterChatLanguageModel) DoStream(
 
 			// Handle text delta
 			if delta.Content != nil {
-				if !yield(api.TextDeltaEvent{
+				if !yield(&api.TextDeltaEvent{
 					TextDelta: *delta.Content,
 				}) {
 					return
@@ -381,7 +401,7 @@ func (m *OpenRouterChatLanguageModel) DoStream(
 
 			// Handle reasoning delta
 			if delta.Reasoning != nil {
-				if !yield(api.ReasoningEvent{
+				if !yield(&api.ReasoningEvent{
 					TextDelta: *delta.Reasoning,
 				}) {
 					return
@@ -409,7 +429,7 @@ func (m *OpenRouterChatLanguageModel) DoStream(
 
 					if tc.Function.Arguments != "" {
 						toolCall.Function.Arguments += tc.Function.Arguments
-						if !yield(api.ToolCallDeltaEvent{
+						if !yield(&api.ToolCallDeltaEvent{
 							ToolCallID: toolCall.ID,
 							ToolName:   toolCall.Function.Name,
 							ArgsDelta:  []byte(tc.Function.Arguments),
@@ -450,11 +470,20 @@ func (m *OpenRouterChatLanguageModel) DoStream(
 				// }
 
 				finishReason := codec.DecodeFinishReason(choice.FinishReason)
-				if !yield(api.FinishEvent{
+				var usage api.Usage
+				if chunk.Usage != nil {
+					usage = api.Usage{
+						InputTokens:  chunk.Usage.PromptTokens,
+						OutputTokens: chunk.Usage.CompletionTokens,
+						TotalTokens:  chunk.Usage.PromptTokens + chunk.Usage.CompletionTokens,
+					}
+				}
+
+				if !yield(&api.FinishEvent{
 					FinishReason: finishReason,
+					Usage:        usage,
 					// TODO: Add logprobs support and usage support
 					// LogProbs:     logprobs,
-					// Usage:        &usage,
 				}) {
 					return
 				}
@@ -462,27 +491,11 @@ func (m *OpenRouterChatLanguageModel) DoStream(
 		}
 
 		if err := scanner.Err(); err != nil {
-			yield(api.ErrorEvent{
+			yield(&api.ErrorEvent{
 				Err: fmt.Errorf("scanner error: %w", err),
 			})
 		}
 	}
 
-	return api.StreamResponse{Events: events}, nil
-}
-
-// stringValue returns an empty string if the pointer is nil, otherwise returns the string value
-func stringValue(s *string) string {
-	if s == nil {
-		return ""
-	}
-	return *s
-}
-
-// convertReasoning converts a string reasoning to a slice of api.Reasoning
-func convertReasoning(s *string) []api.Reasoning {
-	if s == nil || *s == "" {
-		return nil
-	}
-	return []api.Reasoning{&api.ReasoningBlock{Text: *s}}
+	return api.StreamResponse{Stream: stream}, nil
 }

--- a/aisdk/ai/provider/internal/openrouter/openrouter_chat_language_model_test.go
+++ b/aisdk/ai/provider/internal/openrouter/openrouter_chat_language_model_test.go
@@ -8,7 +8,6 @@ import (
 	"go.jetify.com/ai/aitesting"
 	"go.jetify.com/ai/api"
 	"go.jetify.com/ai/provider/internal/openrouter/client"
-	"go.jetify.com/ai/provider/internal/openrouter/codec"
 	"go.jetify.com/pkg/httpmock"
 )
 
@@ -105,7 +104,9 @@ func TestDoGenerate(t *testing.T) {
 				Content: "Hello, World!",
 			},
 			expectedResp: api.Response{
-				Text: "Hello, World!",
+				Content: []api.ContentBlock{
+					&api.TextBlock{Text: "Hello, World!"},
+				},
 			},
 		},
 		{
@@ -132,7 +133,8 @@ func TestDoGenerate(t *testing.T) {
 				LogProbs: testLogprobs,
 			},
 			expectedResp: api.Response{
-				LogProbs: codec.DecodeLogProbs(testLogprobs),
+				// TODO: LogProbs support not yet implemented in the new interface
+				// LogProbs: codec.DecodeLogProbs(testLogprobs),
 			},
 		},
 		{

--- a/aisdk/ai/provider/openai/internal/codec/decode_stream.go
+++ b/aisdk/ai/provider/openai/internal/codec/decode_stream.go
@@ -68,7 +68,7 @@ func (d *streamDecoder) DecodeStream(stream StreamReader) (api.StreamResponse, e
 	}
 
 	return api.StreamResponse{
-		Events: d.decodeEvents(stream),
+		Stream: d.decodeEvents(stream),
 	}, nil
 }
 

--- a/aisdk/ai/provider/openai/internal/codec/decode_stream_test.go
+++ b/aisdk/ai/provider/openai/internal/codec/decode_stream_test.go
@@ -111,7 +111,7 @@ func TestDecodeStreamEvents(t *testing.T) {
 
 			// Collect all events from the stream
 			var got []api.StreamEvent
-			for event := range result.Events {
+			for event := range result.Stream {
 				got = append(got, event)
 			}
 

--- a/aisdk/ai/provider/openai/internal/codec/encode_tools.go
+++ b/aisdk/ai/provider/openai/internal/codec/encode_tools.go
@@ -125,6 +125,24 @@ func encodeProviderDefinedTool(tool api.ProviderDefinedTool) (*responses.ToolUni
 			return nil, nil, err
 		}
 	case "openai.web_search_preview":
+		// TODO: Decide how to evolve handling of the web search tool.
+		// So far, there are three types of tools:
+		// 1. User provided tools (function calls)
+		// 2. Built in or provider defined tools that require the client to perform the action
+		// 3. Built in or provider defined tools where the LLM can perform the action by itself.
+		//
+		// Web search is an example where the LLM already performs the action automatically,
+		// and it's already returning a list of sources, along with the text that it generated.
+		//
+		// We have a few options:
+		// 1. Ignore it. The tool has already been executed. The text already contains the sources.
+		//This is what Vercel does.
+		// 2. Include it. But maybe we should mark it as already executed somehow so users can distinguish.
+		// 3. Instead of including it as a ToolCall, include it as a ToolResult. Normally, ToolResults are
+		//    sent by the client as part of the prompt, letting the LLM know that the tool it requested has
+		//    been executed. But it might be OK, to allow the LLM to return a ToolResult as part of the response
+		//    in cases when it executes a tool by itself.
+
 		result, err = encodeWebSearchTool(tool)
 		if err != nil {
 			return nil, nil, err

--- a/aisdk/ai/provider/openai/llm.go
+++ b/aisdk/ai/provider/openai/llm.go
@@ -89,7 +89,9 @@ func (m *LanguageModel) Generate(
 func (m *LanguageModel) Stream(
 	ctx context.Context, prompt []api.Message, opts api.CallOptions,
 ) (api.StreamResponse, error) {
-	params, warnings, err := codec.Encode(m.modelID, prompt, opts)
+	// TODO: add warnings to the stream response by adding an initial StreamStart event
+	// (it could happen inside of codec.Encode)
+	params, _, err := codec.Encode(m.modelID, prompt, opts)
 	if err != nil {
 		return api.StreamResponse{}, err
 	}
@@ -100,6 +102,5 @@ func (m *LanguageModel) Stream(
 		return api.StreamResponse{}, err
 	}
 
-	response.Warnings = append(response.Warnings, warnings...)
 	return response, nil
 }

--- a/aisdk/ai/provider/openai/llm_test.go
+++ b/aisdk/ai/provider/openai/llm_test.go
@@ -147,7 +147,9 @@ func TestGenerate(t *testing.T) {
 			prompt:    standardPrompt,
 			exchanges: standardExchange,
 			expectedResp: api.Response{
-				Text: "answer text",
+				Content: []api.ContentBlock{
+					&api.TextBlock{Text: "answer text"},
+				},
 			},
 		},
 		{
@@ -235,7 +237,9 @@ func TestGenerate(t *testing.T) {
 				},
 			},
 			expectedResp: api.Response{
-				Text: "answer text",
+				Content: []api.ContentBlock{
+					&api.TextBlock{Text: "answer text"},
+				},
 				// We don't expect any warnings
 				Warnings: []api.CallWarning{},
 			},
@@ -282,7 +286,9 @@ func TestGenerate(t *testing.T) {
 				},
 			},
 			expectedResp: api.Response{
-				Text: "answer text",
+				Content: []api.ContentBlock{
+					&api.TextBlock{Text: "answer text"},
+				},
 				Warnings: []api.CallWarning{
 					{
 						Type:    "unsupported-setting",
@@ -347,7 +353,9 @@ func TestGenerate(t *testing.T) {
 				},
 			},
 			expectedResp: api.Response{
-				Text: "answer text",
+				Content: []api.ContentBlock{
+					&api.TextBlock{Text: "answer text"},
+				},
 				Warnings: []api.CallWarning{
 					{
 						Type:    "unsupported-setting",
@@ -428,7 +436,9 @@ func TestGenerate(t *testing.T) {
 				},
 			},
 			expectedResp: api.Response{
-				Text:     "answer text",
+				Content: []api.ContentBlock{
+					&api.TextBlock{Text: "answer text"},
+				},
 				Warnings: []api.CallWarning{},
 			},
 		},
@@ -473,7 +483,9 @@ func TestGenerate(t *testing.T) {
 				},
 			},
 			expectedResp: api.Response{
-				Text:     "answer text",
+				Content: []api.ContentBlock{
+					&api.TextBlock{Text: "answer text"},
+				},
 				Warnings: []api.CallWarning{},
 			},
 		},
@@ -516,7 +528,9 @@ func TestGenerate(t *testing.T) {
 				},
 			},
 			expectedResp: api.Response{
-				Text:     "answer text",
+				Content: []api.ContentBlock{
+					&api.TextBlock{Text: "answer text"},
+				},
 				Warnings: []api.CallWarning{},
 			},
 		},
@@ -559,7 +573,9 @@ func TestGenerate(t *testing.T) {
 				},
 			},
 			expectedResp: api.Response{
-				Text:     "answer text",
+				Content: []api.ContentBlock{
+					&api.TextBlock{Text: "answer text"},
+				},
 				Warnings: []api.CallWarning{},
 			},
 		},
@@ -602,7 +618,9 @@ func TestGenerate(t *testing.T) {
 				},
 			},
 			expectedResp: api.Response{
-				Text:     "answer text",
+				Content: []api.ContentBlock{
+					&api.TextBlock{Text: "answer text"},
+				},
 				Warnings: []api.CallWarning{},
 			},
 		},
@@ -645,7 +663,9 @@ func TestGenerate(t *testing.T) {
 				},
 			},
 			expectedResp: api.Response{
-				Text:     "answer text",
+				Content: []api.ContentBlock{
+					&api.TextBlock{Text: "answer text"},
+				},
 				Warnings: []api.CallWarning{},
 			},
 		},
@@ -690,7 +710,9 @@ func TestGenerate(t *testing.T) {
 				},
 			},
 			expectedResp: api.Response{
-				Text:     "answer text",
+				Content: []api.ContentBlock{
+					&api.TextBlock{Text: "answer text"},
+				},
 				Warnings: []api.CallWarning{},
 			},
 		},
@@ -733,7 +755,9 @@ func TestGenerate(t *testing.T) {
 				},
 			},
 			expectedResp: api.Response{
-				Text:     "answer text",
+				Content: []api.ContentBlock{
+					&api.TextBlock{Text: "answer text"},
+				},
 				Warnings: []api.CallWarning{},
 			},
 		},
@@ -776,7 +800,9 @@ func TestGenerate(t *testing.T) {
 				},
 			},
 			expectedResp: api.Response{
-				Text:     "answer text",
+				Content: []api.ContentBlock{
+					&api.TextBlock{Text: "answer text"},
+				},
 				Warnings: []api.CallWarning{},
 			},
 		},
@@ -853,7 +879,9 @@ func TestGenerate(t *testing.T) {
 				},
 			},
 			expectedResp: api.Response{
-				Text:     "answer text",
+				Content: []api.ContentBlock{
+					&api.TextBlock{Text: "answer text"},
+				},
 				Warnings: []api.CallWarning{},
 			},
 		},
@@ -898,7 +926,9 @@ func TestGenerate(t *testing.T) {
 				},
 			},
 			expectedResp: api.Response{
-				Text:     "answer text",
+				Content: []api.ContentBlock{
+					&api.TextBlock{Text: "answer text"},
+				},
 				Warnings: []api.CallWarning{},
 			},
 		},
@@ -966,7 +996,9 @@ func TestGenerate(t *testing.T) {
 				},
 			},
 			expectedResp: api.Response{
-				Text:     "answer text",
+				Content: []api.ContentBlock{
+					&api.TextBlock{Text: "answer text"},
+				},
 				Warnings: []api.CallWarning{},
 			},
 		},
@@ -1039,7 +1071,9 @@ func TestGenerate(t *testing.T) {
 				},
 			},
 			expectedResp: api.Response{
-				Text:     "answer text",
+				Content: []api.ContentBlock{
+					&api.TextBlock{Text: "answer text"},
+				},
 				Warnings: []api.CallWarning{},
 			},
 		},
@@ -1094,7 +1128,9 @@ func TestGenerate(t *testing.T) {
 				},
 			},
 			expectedResp: api.Response{
-				Text:     "answer text",
+				Content: []api.ContentBlock{
+					&api.TextBlock{Text: "answer text"},
+				},
 				Warnings: []api.CallWarning{},
 			},
 		},
@@ -1156,7 +1192,9 @@ func TestGenerate(t *testing.T) {
 				},
 			},
 			expectedResp: api.Response{
-				Text:     "answer text",
+				Content: []api.ContentBlock{
+					&api.TextBlock{Text: "answer text"},
+				},
 				Warnings: []api.CallWarning{},
 			},
 		},
@@ -1198,7 +1236,9 @@ func TestGenerate(t *testing.T) {
 				},
 			},
 			expectedResp: api.Response{
-				Text: "answer text",
+				Content: []api.ContentBlock{
+					&api.TextBlock{Text: "answer text"},
+				},
 				Warnings: []api.CallWarning{
 					{Type: "unsupported-setting", Setting: "FrequencyPenalty"},
 					{Type: "unsupported-setting", Setting: "PresencePenalty"},
@@ -1346,13 +1386,13 @@ func TestGenerate_ToolCalls(t *testing.T) {
 			},
 			exchanges: standardExchange,
 			expectedResp: api.Response{
-				ToolCalls: []api.ToolCallBlock{
-					{
+				Content: []api.ContentBlock{
+					&api.ToolCallBlock{
 						ToolCallID: "call_0NdsJqOS8N3J9l2p0p4WpYU9",
 						ToolName:   "weather",
 						Args:       json.RawMessage(`{"location":"San Francisco"}`),
 					},
-					{
+					&api.ToolCallBlock{
 						ToolCallID: "call_gexo0HtjUfmAIW4gjNOgyrcr",
 						ToolName:   "cityAttractions",
 						Args:       json.RawMessage(`{"city":"San Francisco"}`),
@@ -1555,7 +1595,13 @@ func TestGenerate_WebSearch(t *testing.T) {
 				},
 			},
 			expectedResp: api.Response{
-				Text: expectedText,
+				Content: []api.ContentBlock{
+					&api.ToolCallBlock{
+						ToolCallID: "ws_67cf2b3051e88190b006770db6fdb13d",
+						ToolName:   "openai.web_search_preview",
+					},
+					&api.TextBlock{Text: expectedText},
+				},
 			},
 		},
 		{
@@ -1574,36 +1620,36 @@ func TestGenerate_WebSearch(t *testing.T) {
 				},
 			},
 			expectedResp: api.Response{
-				Sources: []api.Source{
-					{
-						SourceType: "url",
-						ID:         "source-0",
-						URL:        "https://www.axios.com/local/san-francisco/2025/03/07/bruce-lee-statue-sf-chinatown?utm_source=chatgpt.com",
-						Title:      "Bruce Lee statue to be installed in SF Chinatown",
+				Content: []api.ContentBlock{
+					&api.ToolCallBlock{
+						ToolCallID: "ws_67cf2b3051e88190b006770db6fdb13d",
+						ToolName:   "openai.web_search_preview",
 					},
-					{
-						SourceType: "url",
-						ID:         "source-1",
-						URL:        "https://www.axios.com/local/san-francisco/2025/03/03/bay-area-office-leasing-activity?utm_source=chatgpt.com",
-						Title:      "The Bay Area is set to make an office leasing comeback",
+					&api.TextBlock{Text: expectedText},
+					&api.SourceBlock{
+						ID:    "source-0",
+						URL:   "https://www.axios.com/local/san-francisco/2025/03/07/bruce-lee-statue-sf-chinatown?utm_source=chatgpt.com",
+						Title: "Bruce Lee statue to be installed in SF Chinatown",
 					},
-					{
-						SourceType: "url",
-						ID:         "source-2",
-						URL:        "https://www.axios.com/local/san-francisco/2025/03/03/where-to-see-spring-blooms-bay-area?utm_source=chatgpt.com",
-						Title:      "Where to see spring blooms in the Bay Area",
+					&api.SourceBlock{
+						ID:    "source-1",
+						URL:   "https://www.axios.com/local/san-francisco/2025/03/03/bay-area-office-leasing-activity?utm_source=chatgpt.com",
+						Title: "The Bay Area is set to make an office leasing comeback",
 					},
-					{
-						SourceType: "url",
-						ID:         "source-3",
-						URL:        "https://www.axios.com/local/san-francisco/2025/03/03/great-highway-park-opening-april-recall-campaign?utm_source=chatgpt.com",
-						Title:      "Oceanfront Great Highway park set to open in April",
+					&api.SourceBlock{
+						ID:    "source-2",
+						URL:   "https://www.axios.com/local/san-francisco/2025/03/03/where-to-see-spring-blooms-bay-area?utm_source=chatgpt.com",
+						Title: "Where to see spring blooms in the Bay Area",
 					},
-					{
-						SourceType: "url",
-						ID:         "source-4",
-						URL:        "https://www.axios.com/local/san-francisco/2025/03/03/climate-weather-spring-temperatures-warmer-sf?utm_source=chatgpt.com",
-						Title:      "San Francisco's spring seasons are getting warmer",
+					&api.SourceBlock{
+						ID:    "source-3",
+						URL:   "https://www.axios.com/local/san-francisco/2025/03/03/great-highway-park-opening-april-recall-campaign?utm_source=chatgpt.com",
+						Title: "Oceanfront Great Highway park set to open in April",
+					},
+					&api.SourceBlock{
+						ID:    "source-4",
+						URL:   "https://www.axios.com/local/san-francisco/2025/03/03/climate-weather-spring-temperatures-warmer-sf?utm_source=chatgpt.com",
+						Title: "San Francisco's spring seasons are getting warmer",
 					},
 				},
 			},
@@ -3013,7 +3059,7 @@ func runStreamTests(t *testing.T, tests []struct {
 
 			// Collect all events from the stream
 			var gotEvents []api.StreamEvent
-			for event := range resp.Events {
+			for event := range resp.Stream {
 				gotEvents = append(gotEvents, event)
 			}
 


### PR DESCRIPTION
## Summary
Replace separate Response fields (Text, ToolCalls, Sources, Reasoning) with a unified Content []ContentBlock array to maintain output order and simplify API.

- Consolidate all response content into sequential ContentBlock array
- Add a SourceBlock
- Update all provider implementations (OpenAI, Anthropic, OpenRouter)
- Update builders and tests for new unified structure
- Remove deprecated fields like LogProbs from main Response struct

BREAKING CHANGE

## How was it tested?
Updated tests and ran them.

## Community Contribution License

All community contributions in this pull request are licensed to the project maintainers under the terms of the [Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request I represent that I have the right to license the contributions to the project maintainers under the Apache 2 License as stated in the [Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).
