### PR TITLE
Add serialization support for Call Options

### DIFF
--- a/aisdk/ai/api/llm_call_options_test.go
+++ b/aisdk/ai/api/llm_call_options_test.go
@@ -1,0 +1,253 @@
+package api
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCallOptions_JSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		jsonStr string
+	}{
+		{
+			name: "basic_options",
+			jsonStr: `{
+				"max_output_tokens": 1000,
+				"temperature": 0.7,
+				"top_p": 0.9,
+				"stop_sequences": ["STOP", "END"]
+			}`,
+		},
+		{
+			name: "complex_options_with_response_format",
+			jsonStr: `{
+				"max_output_tokens": 2000,
+				"temperature": 0.5,
+				"top_k": 40,
+				"presence_penalty": 0.1,
+				"frequency_penalty": 0.2,
+				"seed": 12345,
+				"response_format": {
+					"type": "json",
+					"name": "response",
+					"description": "A structured response"
+				},
+				"headers": {
+					"X-Custom-Header": "custom-value",
+					"Authorization": "Bearer token"
+				}
+			}`,
+		},
+		{
+			name: "all_fields_comprehensive",
+			jsonStr: `{
+				"max_output_tokens": 4000,
+				"temperature": 0.8,
+				"stop_sequences": ["STOP", "END", "FINISH"],
+				"top_p": 0.95,
+				"top_k": 50,
+				"presence_penalty": 0.3,
+				"frequency_penalty": 0.4,
+				"response_format": {
+					"type": "json",
+					"schema": {
+						"type": "object",
+						"properties": {
+							"name": {"type": "string"},
+							"age": {"type": "integer"}
+						},
+						"required": ["name"],
+						"additionalProperties": false
+					},
+					"name": "user_info",
+					"description": "User information structure"
+				},
+				"seed": 67890,
+				"tools": [
+					{
+						"type": "function",
+						"name": "get_weather",
+						"description": "Get weather information",
+						"input_schema": {
+							"type": "object",
+							"properties": {
+								"location": {"type": "string"},
+								"units": {"type": "string", "enum": ["metric", "imperial"]}
+							},
+							"required": ["location"],
+							"additionalProperties": false
+						}
+					},
+					{
+						"type": "provider-defined",
+						"id": "openai.file_search",
+						"name": "file_search",
+						"args": {
+							"vector_store_ids": ["store1", "store2"],
+							"max_num_results": 20
+						}
+					}
+				],
+				"tool_choice": {
+					"type": "tool",
+					"tool_name": "get_weather"
+				},
+				"headers": {
+					"X-API-Key": "test-key",
+					"User-Agent": "test-agent",
+					"Content-Type": "application/json"
+				},
+				"provider_metadata": {
+					"openai": {
+						"custom_param": "custom_value",
+						"extra_config": true
+					},
+					"anthropic": {
+						"model_version": "claude-3"
+					}
+				}
+			}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Unmarshal JSON string into CallOptions
+			var callOptions CallOptions
+			err := json.Unmarshal([]byte(tt.jsonStr), &callOptions)
+			require.NoError(t, err, "Failed to unmarshal JSON")
+
+			// Marshal CallOptions back to JSON
+			serializedJSON, err := json.Marshal(callOptions)
+			require.NoError(t, err, "Failed to marshal CallOptions")
+
+			// Compare original and re-serialized JSON
+			assert.JSONEq(t, tt.jsonStr, string(serializedJSON), "JSON round-trip failed")
+		})
+	}
+}
+
+// BenchmarkCallOptionsUnmarshal benchmarks the performance of UnmarshalJSON
+func BenchmarkCallOptionsUnmarshal(b *testing.B) {
+	// Complex test case with tools (from existing test)
+	jsonData := []byte(`{
+		"max_output_tokens": 4000,
+		"temperature": 0.8,
+		"stop_sequences": ["STOP", "END", "FINISH"],
+		"top_p": 0.95,
+		"top_k": 50,
+		"presence_penalty": 0.3,
+		"frequency_penalty": 0.4,
+		"response_format": {
+			"type": "json",
+			"schema": {
+				"type": "object",
+				"properties": {
+					"name": {"type": "string"},
+					"age": {"type": "integer"}
+				},
+				"required": ["name"],
+				"additionalProperties": false
+			},
+			"name": "user_info",
+			"description": "User information structure"
+		},
+		"seed": 67890,
+		"tools": [
+			{
+				"type": "function",
+				"name": "get_weather",
+				"description": "Get weather information",
+				"input_schema": {
+					"type": "object",
+					"properties": {
+						"location": {"type": "string"},
+						"units": {"type": "string", "enum": ["metric", "imperial"]}
+					},
+					"required": ["location"],
+					"additionalProperties": false
+				}
+			},
+			{
+				"type": "provider-defined",
+				"id": "openai.file_search",
+				"name": "file_search",
+				"args": {
+					"vector_store_ids": ["store1", "store2"],
+					"max_num_results": 20
+				}
+			}
+		],
+		"tool_choice": {
+			"type": "tool",
+			"tool_name": "get_weather"
+		},
+		"headers": {
+			"X-API-Key": "test-key",
+			"User-Agent": "test-agent",
+			"Content-Type": "application/json"
+		},
+		"provider_metadata": {
+			"openai": {
+				"custom_param": "custom_value",
+				"extra_config": true
+			},
+			"anthropic": {
+				"model_version": "claude-3"
+			}
+		}
+	}`)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		var callOptions CallOptions
+		err := json.Unmarshal(jsonData, &callOptions)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkCallOptionsUnmarshalManyTools tests performance with many tools
+func BenchmarkCallOptionsUnmarshalManyTools(b *testing.B) {
+	// Generate JSON with many tools to test scaling
+	toolsJSON := ""
+	for i := 0; i < 50; i++ {
+		if i > 0 {
+			toolsJSON += ","
+		}
+		toolsJSON += `{
+			"type": "function",
+			"name": "tool_` + string(rune('A'+i%26)) + `",
+			"description": "Tool description",
+			"input_schema": {
+				"type": "object",
+				"properties": {
+					"param": {"type": "string"}
+				}
+			}
+		}`
+	}
+
+	jsonData := []byte(`{
+		"max_output_tokens": 1000,
+		"tools": [` + toolsJSON + `]
+	}`)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		var callOptions CallOptions
+		err := json.Unmarshal(jsonData, &callOptions)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/aisdk/ai/api/llm_provider_metadata.go
+++ b/aisdk/ai/api/llm_provider_metadata.go
@@ -56,6 +56,15 @@ func (p *ProviderMetadata) MarshalJSON() ([]byte, error) {
 	return json.Marshal(p.data)
 }
 
+// UnmarshalJSON implements the json.Unmarshaler interface.
+// It deserializes JSON into the underlying data map.
+func (p *ProviderMetadata) UnmarshalJSON(data []byte) error {
+	if p.data == nil {
+		p.data = make(map[string]any)
+	}
+	return json.Unmarshal(data, &p.data)
+}
+
 // IsZero returns true if this ProviderMetadata is a zero value or contains no data.
 func (p *ProviderMetadata) IsZero() bool {
 	return p == nil || len(p.data) == 0

--- a/aisdk/ai/api/llm_tool.go
+++ b/aisdk/ai/api/llm_tool.go
@@ -2,7 +2,11 @@ package api
 
 // TODO: This schema package is pretty small.
 // It might be best to just in line it into our AI SDK.
-import "github.com/sashabaranov/go-openai/jsonschema"
+import (
+	"encoding/json"
+
+	"github.com/sashabaranov/go-openai/jsonschema"
+)
 
 // ToolChoice specifies how tools should be selected by the model.
 type ToolChoice struct {
@@ -20,8 +24,10 @@ type ToolChoice struct {
 // ToolDefinition represents a tool that can be used in a language model call.
 // It can either be a user-defined tool or a built-in provider-defined tool.
 type ToolDefinition interface {
-	// ToolType is the type of the tool. Either "function" or "provider-defined".
-	ToolType() string
+	// Type is the type of the tool. Either "function" or "provider-defined".
+	Type() string
+
+	isToolDefinition() bool
 }
 
 // FunctionTool represents a tool that has a name, description, and set of input arguments.
@@ -44,22 +50,56 @@ type FunctionTool struct {
 var _ ToolDefinition = &FunctionTool{}
 
 // Type is the type of the tool (always "function")
-func (t FunctionTool) ToolType() string { return "function" }
+func (t FunctionTool) Type() string { return "function" }
+
+// isToolDefinition is a marker method to satisfy the ToolDefinition interface
+func (t FunctionTool) isToolDefinition() bool { return true }
+
+// FunctionTool JSON marshaling - automatically includes "type" field
+func (t FunctionTool) MarshalJSON() ([]byte, error) {
+	type Alias FunctionTool
+	return json.Marshal(struct {
+		Type string `json:"type"`
+		*Alias
+	}{
+		Type:  "function",
+		Alias: (*Alias)(&t),
+	})
+}
 
 // ProviderDefinedTool represents a tool that has built-in support by the provider.
 // Provider implementations will usually predefine these.
-type ProviderDefinedTool interface {
-	// ToolType is the type of the tool. Always "provider-defined" for provider-defined tools.
-	ToolType() string
-
+type ProviderDefinedTool struct {
 	// ID is the tool identifier in format "<provider-name>.<tool-name>"
-	ID() string
+	ID string `json:"id"`
 
 	// Name returns the unique name used to identify this tool within the model's messages.
 	// This is the name that will be used by the language model as the value of the ToolName field
 	// in ToolCall blocks.
-	Name() string
+	Name string `json:"name"`
 
-	// TODO: Consider adding a Validate method that checks if the arguments are valid and returns an error otherwise.
-	// This would be used to validate the tool call arguments before sending them to the language model.
+	// Args contains the arguments for configuring the tool. Must match the expected arguments
+	// defined by the provider for this tool.
+	// Providers should support both a JSON-serializable type and a map[string]interface{} type.
+	Args any `json:"args"`
+}
+
+var _ ToolDefinition = &ProviderDefinedTool{}
+
+// Type is the type of the tool (always "provider-defined")
+func (t ProviderDefinedTool) Type() string { return "provider-defined" }
+
+// isToolDefinition is a marker method to satisfy the ToolDefinition interface
+func (t ProviderDefinedTool) isToolDefinition() bool { return true }
+
+// ProviderDefinedTool JSON marshaling - automatically includes "type" field
+func (t ProviderDefinedTool) MarshalJSON() ([]byte, error) {
+	type Alias ProviderDefinedTool
+	return json.Marshal(struct {
+		Type string `json:"type"`
+		*Alias
+	}{
+		Type:  "provider-defined",
+		Alias: (*Alias)(&t),
+	})
 }

--- a/aisdk/ai/provider/anthropic/codec/encode_tools_test.go
+++ b/aisdk/ai/provider/anthropic/codec/encode_tools_test.go
@@ -168,13 +168,59 @@ func TestEncodeProviderDefinedTool(t *testing.T) {
 		wantErrMsg   string            // Empty means no error, non-empty means expect error containing this string
 		want         anthropic.BetaToolUnionUnionParam
 	}{
+		// Computer tool tests using constructor functions
 		{
-			name: "computer tool with version 20250124",
-			input: &ComputerUseTool{
-				Version:         "20250124",
-				DisplayWidthPx:  800,
-				DisplayHeightPx: 600,
-				DisplayNumber:   1,
+			name:         "computer tool with version 20250124 (constructor)",
+			input:        ComputerTool(800, 600, WithComputerVersion("20250124"), WithDisplayNumber(1)),
+			expectBetas:  []string{anthropic.AnthropicBetaComputerUse2025_01_24},
+			wantWarnings: nil,
+			want: anthropic.BetaToolComputerUse20250124Param{
+				Name:            anthropic.F(anthropic.BetaToolComputerUse20250124Name("computer")),
+				Type:            anthropic.F(anthropic.BetaToolComputerUse20250124TypeComputer20250124),
+				DisplayWidthPx:  anthropic.Int(800),
+				DisplayHeightPx: anthropic.Int(600),
+				DisplayNumber:   anthropic.Int(1),
+			},
+		},
+		{
+			name:         "computer tool with version 20241022 (constructor)",
+			input:        ComputerTool(800, 600, WithComputerVersion("20241022"), WithDisplayNumber(1)),
+			expectBetas:  []string{anthropic.AnthropicBetaComputerUse2024_10_22},
+			wantWarnings: nil,
+			want: anthropic.BetaToolComputerUse20241022Param{
+				Name:            anthropic.F(anthropic.BetaToolComputerUse20241022Name("computer")),
+				Type:            anthropic.F(anthropic.BetaToolComputerUse20241022TypeComputer20241022),
+				DisplayWidthPx:  anthropic.Int(800),
+				DisplayHeightPx: anthropic.Int(600),
+				DisplayNumber:   anthropic.Int(1),
+			},
+		},
+		{
+			name:         "computer tool with default version (constructor)",
+			input:        ComputerTool(800, 600, WithDisplayNumber(1)),
+			expectBetas:  []string{anthropic.AnthropicBetaComputerUse2025_01_24},
+			wantWarnings: nil,
+			want: anthropic.BetaToolComputerUse20250124Param{
+				Name:            anthropic.F(anthropic.BetaToolComputerUse20250124Name("computer")),
+				Type:            anthropic.F(anthropic.BetaToolComputerUse20250124TypeComputer20250124),
+				DisplayWidthPx:  anthropic.Int(800),
+				DisplayHeightPx: anthropic.Int(600),
+				DisplayNumber:   anthropic.Int(1),
+			},
+		},
+
+		// Computer tool tests using map[string]any args
+		{
+			name: "computer tool with version 20250124 (map args)",
+			input: api.ProviderDefinedTool{
+				ID:   "anthropic.computer",
+				Name: "computer",
+				Args: map[string]any{
+					"version":           "20250124",
+					"display_width_px":  800,
+					"display_height_px": 600,
+					"display_number":    1,
+				},
 			},
 			expectBetas:  []string{anthropic.AnthropicBetaComputerUse2025_01_24},
 			wantWarnings: nil,
@@ -187,12 +233,16 @@ func TestEncodeProviderDefinedTool(t *testing.T) {
 			},
 		},
 		{
-			name: "computer tool with version 20241022",
-			input: &ComputerUseTool{
-				Version:         "20241022",
-				DisplayWidthPx:  800,
-				DisplayHeightPx: 600,
-				DisplayNumber:   1,
+			name: "computer tool with version 20241022 (map args)",
+			input: api.ProviderDefinedTool{
+				ID:   "anthropic.computer",
+				Name: "computer",
+				Args: map[string]any{
+					"version":           "20241022",
+					"display_width_px":  800,
+					"display_height_px": 600,
+					"display_number":    1,
+				},
 			},
 			expectBetas:  []string{anthropic.AnthropicBetaComputerUse2024_10_22},
 			wantWarnings: nil,
@@ -205,11 +255,15 @@ func TestEncodeProviderDefinedTool(t *testing.T) {
 			},
 		},
 		{
-			name: "computer tool with default version",
-			input: &ComputerUseTool{
-				DisplayWidthPx:  800,
-				DisplayHeightPx: 600,
-				DisplayNumber:   1,
+			name: "computer tool with default version (map args)",
+			input: api.ProviderDefinedTool{
+				ID:   "anthropic.computer",
+				Name: "computer",
+				Args: map[string]any{
+					"display_width_px":  800,
+					"display_height_px": 600,
+					"display_number":    1,
+				},
 			},
 			expectBetas:  []string{anthropic.AnthropicBetaComputerUse2025_01_24},
 			wantWarnings: nil,
@@ -221,10 +275,48 @@ func TestEncodeProviderDefinedTool(t *testing.T) {
 				DisplayNumber:   anthropic.Int(1),
 			},
 		},
+
+		// Text editor tool tests using constructor functions
 		{
-			name: "text editor tool with version 20250124",
-			input: &TextEditorTool{
-				Version: "20250124",
+			name:         "text editor tool with version 20250124 (constructor)",
+			input:        TextEditorTool(WithTextEditorVersion("20250124")),
+			expectBetas:  []string{anthropic.AnthropicBetaComputerUse2025_01_24},
+			wantWarnings: nil,
+			want: anthropic.BetaToolTextEditor20250124Param{
+				Name: anthropic.F(anthropic.BetaToolTextEditor20250124Name("str_replace_editor")),
+				Type: anthropic.F(anthropic.BetaToolTextEditor20250124TypeTextEditor20250124),
+			},
+		},
+		{
+			name:         "text editor tool with version 20241022 (constructor)",
+			input:        TextEditorTool(WithTextEditorVersion("20241022")),
+			expectBetas:  []string{anthropic.AnthropicBetaComputerUse2024_10_22},
+			wantWarnings: nil,
+			want: anthropic.BetaToolTextEditor20241022Param{
+				Name: anthropic.F(anthropic.BetaToolTextEditor20241022Name("str_replace_editor")),
+				Type: anthropic.F(anthropic.BetaToolTextEditor20241022TypeTextEditor20241022),
+			},
+		},
+		{
+			name:         "text editor tool with default version (constructor)",
+			input:        TextEditorTool(),
+			expectBetas:  []string{anthropic.AnthropicBetaComputerUse2025_01_24},
+			wantWarnings: nil,
+			want: anthropic.BetaToolTextEditor20250124Param{
+				Name: anthropic.F(anthropic.BetaToolTextEditor20250124Name("str_replace_editor")),
+				Type: anthropic.F(anthropic.BetaToolTextEditor20250124TypeTextEditor20250124),
+			},
+		},
+
+		// Text editor tool tests using map[string]any args
+		{
+			name: "text editor tool with version 20250124 (map args)",
+			input: api.ProviderDefinedTool{
+				ID:   "anthropic.text_editor",
+				Name: "str_replace_editor",
+				Args: map[string]any{
+					"version": "20250124",
+				},
 			},
 			expectBetas:  []string{anthropic.AnthropicBetaComputerUse2025_01_24},
 			wantWarnings: nil,
@@ -234,9 +326,13 @@ func TestEncodeProviderDefinedTool(t *testing.T) {
 			},
 		},
 		{
-			name: "text editor tool with version 20241022",
-			input: &TextEditorTool{
-				Version: "20241022",
+			name: "text editor tool with version 20241022 (map args)",
+			input: api.ProviderDefinedTool{
+				ID:   "anthropic.text_editor",
+				Name: "str_replace_editor",
+				Args: map[string]any{
+					"version": "20241022",
+				},
 			},
 			expectBetas:  []string{anthropic.AnthropicBetaComputerUse2024_10_22},
 			wantWarnings: nil,
@@ -246,8 +342,12 @@ func TestEncodeProviderDefinedTool(t *testing.T) {
 			},
 		},
 		{
-			name:         "text editor tool with default version",
-			input:        &TextEditorTool{},
+			name: "text editor tool with default version (map args)",
+			input: api.ProviderDefinedTool{
+				ID:   "anthropic.text_editor",
+				Name: "str_replace_editor",
+				Args: map[string]any{},
+			},
 			expectBetas:  []string{anthropic.AnthropicBetaComputerUse2025_01_24},
 			wantWarnings: nil,
 			want: anthropic.BetaToolTextEditor20250124Param{
@@ -255,10 +355,48 @@ func TestEncodeProviderDefinedTool(t *testing.T) {
 				Type: anthropic.F(anthropic.BetaToolTextEditor20250124TypeTextEditor20250124),
 			},
 		},
+
+		// Bash tool tests using constructor functions
 		{
-			name: "bash tool with version 20250124",
-			input: &BashTool{
-				Version: "20250124",
+			name:         "bash tool with version 20250124 (constructor)",
+			input:        BashTool(WithBashVersion("20250124")),
+			expectBetas:  []string{anthropic.AnthropicBetaComputerUse2025_01_24},
+			wantWarnings: nil,
+			want: anthropic.BetaToolBash20250124Param{
+				Name: anthropic.F(anthropic.BetaToolBash20250124Name("bash")),
+				Type: anthropic.F(anthropic.BetaToolBash20250124TypeBash20250124),
+			},
+		},
+		{
+			name:         "bash tool with version 20241022 (constructor)",
+			input:        BashTool(WithBashVersion("20241022")),
+			expectBetas:  []string{anthropic.AnthropicBetaComputerUse2024_10_22},
+			wantWarnings: nil,
+			want: anthropic.BetaToolBash20241022Param{
+				Name: anthropic.F(anthropic.BetaToolBash20241022Name("bash")),
+				Type: anthropic.F(anthropic.BetaToolBash20241022TypeBash20241022),
+			},
+		},
+		{
+			name:         "bash tool with default version (constructor)",
+			input:        BashTool(),
+			expectBetas:  []string{anthropic.AnthropicBetaComputerUse2025_01_24},
+			wantWarnings: nil,
+			want: anthropic.BetaToolBash20250124Param{
+				Name: anthropic.F(anthropic.BetaToolBash20250124Name("bash")),
+				Type: anthropic.F(anthropic.BetaToolBash20250124TypeBash20250124),
+			},
+		},
+
+		// Bash tool tests using map[string]any args
+		{
+			name: "bash tool with version 20250124 (map args)",
+			input: api.ProviderDefinedTool{
+				ID:   "anthropic.bash",
+				Name: "bash",
+				Args: map[string]any{
+					"version": "20250124",
+				},
 			},
 			expectBetas:  []string{anthropic.AnthropicBetaComputerUse2025_01_24},
 			wantWarnings: nil,
@@ -268,9 +406,13 @@ func TestEncodeProviderDefinedTool(t *testing.T) {
 			},
 		},
 		{
-			name: "bash tool with version 20241022",
-			input: &BashTool{
-				Version: "20241022",
+			name: "bash tool with version 20241022 (map args)",
+			input: api.ProviderDefinedTool{
+				ID:   "anthropic.bash",
+				Name: "bash",
+				Args: map[string]any{
+					"version": "20241022",
+				},
 			},
 			expectBetas:  []string{anthropic.AnthropicBetaComputerUse2024_10_22},
 			wantWarnings: nil,
@@ -280,8 +422,12 @@ func TestEncodeProviderDefinedTool(t *testing.T) {
 			},
 		},
 		{
-			name:         "bash tool with default version",
-			input:        &BashTool{},
+			name: "bash tool with default version (map args)",
+			input: api.ProviderDefinedTool{
+				ID:   "anthropic.bash",
+				Name: "bash",
+				Args: map[string]any{},
+			},
 			expectBetas:  []string{anthropic.AnthropicBetaComputerUse2025_01_24},
 			wantWarnings: nil,
 			want: anthropic.BetaToolBash20250124Param{
@@ -289,38 +435,62 @@ func TestEncodeProviderDefinedTool(t *testing.T) {
 				Type: anthropic.F(anthropic.BetaToolBash20250124TypeBash20250124),
 			},
 		},
+
+		// Error cases using map[string]any args
 		{
-			name: "computer tool with invalid version",
-			input: &ComputerUseTool{
-				Version:         "invalid",
-				DisplayWidthPx:  800,
-				DisplayHeightPx: 600,
+			name: "computer tool with invalid version (map args)",
+			input: api.ProviderDefinedTool{
+				ID:   "anthropic.computer",
+				Name: "computer",
+				Args: map[string]any{
+					"version":           "invalid",
+					"display_width_px":  800,
+					"display_height_px": 600,
+				},
 			},
 			wantErrMsg: "unsupported computer tool version",
 		},
 		{
-			name: "text editor tool with invalid version",
-			input: &TextEditorTool{
-				Version: "invalid",
+			name: "text editor tool with invalid version (map args)",
+			input: api.ProviderDefinedTool{
+				ID:   "anthropic.text_editor",
+				Name: "str_replace_editor",
+				Args: map[string]any{
+					"version": "invalid",
+				},
 			},
 			wantErrMsg: "unsupported text editor tool version",
 		},
 		{
-			name: "bash tool with invalid version",
-			input: &BashTool{
-				Version: "invalid",
+			name: "bash tool with invalid version (map args)",
+			input: api.ProviderDefinedTool{
+				ID:   "anthropic.bash",
+				Name: "bash",
+				Args: map[string]any{
+					"version": "invalid",
+				},
 			},
 			wantErrMsg: "unsupported bash tool version",
 		},
+
+		// Unsupported tool type
 		{
-			name:        "unsupported tool type",
-			input:       &mockUnsupportedTool{},
+			name: "unsupported tool type",
+			input: api.ProviderDefinedTool{
+				ID:   "mock.unsupported",
+				Name: "unsupported",
+				Args: &unsupportedArgs{},
+			},
 			expectNil:   true,
 			expectBetas: []string{},
 			wantWarnings: []api.CallWarning{
 				{
 					Type: "unsupported-tool",
-					Tool: &mockUnsupportedTool{},
+					Tool: api.ProviderDefinedTool{
+						ID:   "mock.unsupported",
+						Name: "unsupported",
+						Args: &unsupportedArgs{},
+					},
 				},
 			},
 		},
@@ -387,14 +557,22 @@ func TestEncodeTools(t *testing.T) {
 		},
 	}
 
-	computerTool := &ComputerUseTool{
-		DisplayWidthPx:  800,
-		DisplayHeightPx: 600,
-		DisplayNumber:   1,
+	computerTool := api.ProviderDefinedTool{
+		ID:   "anthropic.computer",
+		Name: "computer",
+		Args: &ComputerToolArgs{
+			DisplayWidthPx:  800,
+			DisplayHeightPx: 600,
+			DisplayNumber:   1,
+		},
 	}
 
 	// Use a concrete tool type that we know won't be handled correctly
-	unsupportedTool := &mockUnsupportedTool{}
+	unsupportedTool := api.ProviderDefinedTool{
+		ID:   "mock.unsupported",
+		Name: "unsupported",
+		Args: &unsupportedArgs{},
+	}
 
 	// Helper to create expected tool choice
 	autoChoice := []anthropic.BetaToolChoiceUnionParam{
@@ -527,9 +705,21 @@ func TestEncodeTools(t *testing.T) {
 		{
 			name: "multiple provider tools with same beta",
 			tools: []api.ToolDefinition{
-				&ComputerUseTool{DisplayWidthPx: 800, DisplayHeightPx: 600, DisplayNumber: 1},
-				&TextEditorTool{},
-				&BashTool{},
+				api.ProviderDefinedTool{
+					ID:   "anthropic.computer",
+					Name: "computer",
+					Args: &ComputerToolArgs{DisplayWidthPx: 800, DisplayHeightPx: 600, DisplayNumber: 1},
+				},
+				api.ProviderDefinedTool{
+					ID:   "anthropic.text_editor",
+					Name: "str_replace_editor",
+					Args: &TextEditorToolArgs{},
+				},
+				api.ProviderDefinedTool{
+					ID:   "anthropic.bash",
+					Name: "bash",
+					Args: &BashToolArgs{},
+				},
 			},
 			want: AnthropicTools{
 				Tools: []anthropic.BetaToolUnionUnionParam{
@@ -607,9 +797,5 @@ func mustEncodeBashTool() anthropic.BetaToolUnionUnionParam {
 	}
 }
 
-// mockUnsupportedTool implements the ProviderDefinedTool interface for testing unsupported tools
-type mockUnsupportedTool struct{}
-
-func (t *mockUnsupportedTool) ToolType() string { return "provider-defined" }
-func (t *mockUnsupportedTool) ID() string       { return "mock.unsupported" }
-func (t *mockUnsupportedTool) Name() string     { return "unsupported" }
+// unsupportedArgs is used as Args for testing unsupported tools
+type unsupportedArgs struct{}

--- a/aisdk/ai/provider/anthropic/codec/tools.go
+++ b/aisdk/ai/provider/anthropic/codec/tools.go
@@ -6,6 +6,13 @@ import (
 	"go.jetify.com/ai/api"
 )
 
+// Default versions and recommended settings for Anthropic tools
+const (
+	DefaultToolVersion       = "20250124"
+	RecommendedDisplayWidth  = 1280
+	RecommendedDisplayHeight = 800
+)
+
 // ComputerAction is a ComputerToolCall action.
 type ComputerAction string
 
@@ -94,7 +101,7 @@ const (
 // 	- use ints instead of json.Number while still being flexible about
 // 	  accepting ints, floats, or number strings
 
-// ComputerToolCall contains the parameters of a call to [ComputerUseTool].
+// ComputerToolCall contains the parameters of a call to [ComputerTool].
 type ComputerToolCall struct {
 	// Action is the action to perform. It is the only mandatory field.
 	Action ComputerAction `json:"action"`
@@ -130,10 +137,9 @@ type ComputerToolCall struct {
 	ScrollDirection ScrollDirection `json:"scroll_direction,omitzero"`
 }
 
-// ComputerUseTool is a built-in tool that can be used to control a computer.
-// It allows the model to use a mouse and keyboard and to take screenshots.
+// ComputerToolArgs contains the configuration arguments for the computer use tool.
 // See the [computer use guide](https://docs.anthropic.com/en/docs/agents-and-tools/computer-use) for more details.
-type ComputerUseTool struct {
+type ComputerToolArgs struct {
 	// The version of the computer tool to use.
 	// Optional field, defaults to the latest version. Possible values are: "20250124", "20241022".
 	Version string `json:"version"`
@@ -150,50 +156,118 @@ type ComputerUseTool struct {
 	DisplayNumber int `json:"display_number,omitzero"`
 }
 
-var _ api.ProviderDefinedTool = &ComputerUseTool{}
+// ComputerToolOption allows customizing computer tool configuration.
+type ComputerToolOption func(*ComputerToolArgs)
 
-func (t *ComputerUseTool) ToolType() string { return "provider-defined" }
-
-func (t *ComputerUseTool) ID() string {
-	return "anthropic.computer"
+// WithComputerVersion sets the computer tool version.
+func WithComputerVersion(version string) ComputerToolOption {
+	return func(args *ComputerToolArgs) {
+		args.Version = version
+	}
 }
 
-func (t *ComputerUseTool) Name() string { return "computer" }
+// WithDisplayNumber sets the display number for X11 environments.
+func WithDisplayNumber(displayNum int) ComputerToolOption {
+	return func(args *ComputerToolArgs) {
+		args.DisplayNumber = displayNum
+	}
+}
 
-// BashTool is a built-in tool that can be used to run shell commands.
+// ComputerTool creates a new computer use tool with the specified configuration.
+// ComputerTool is a built-in tool that can be used to control a computer.
+// It allows the model to use a mouse and keyboard and to take screenshots.
 // See the [computer use guide](https://docs.anthropic.com/en/docs/agents-and-tools/computer-use) for more details.
-type BashTool struct {
+func ComputerTool(displayWidth, displayHeight int, options ...ComputerToolOption) api.ProviderDefinedTool {
+	args := &ComputerToolArgs{
+		DisplayWidthPx:  displayWidth,
+		DisplayHeightPx: displayHeight,
+		Version:         DefaultToolVersion,
+	}
+
+	// Apply options
+	for _, opt := range options {
+		opt(args)
+	}
+
+	return api.ProviderDefinedTool{
+		ID:   "anthropic.computer",
+		Name: "computer",
+		Args: args,
+	}
+}
+
+// BashToolArgs contains the configuration arguments for the bash tool.
+// See the [computer use guide](https://docs.anthropic.com/en/docs/agents-and-tools/computer-use) for more details.
+type BashToolArgs struct {
 	// The version of the bash tool to use.
 	// Optional field, defaults to the latest version. Possible values are: "20250124", "20241022".
 	Version string `json:"version"`
 }
 
-var _ api.ProviderDefinedTool = &BashTool{}
+// BashToolOption allows customizing bash tool configuration.
+type BashToolOption func(*BashToolArgs)
 
-func (t *BashTool) ToolType() string { return "provider-defined" }
-
-func (t *BashTool) ID() string {
-	return "anthropic.bash"
+// WithBashVersion sets the bash tool version.
+func WithBashVersion(version string) BashToolOption {
+	return func(args *BashToolArgs) {
+		args.Version = version
+	}
 }
 
-func (t *BashTool) Name() string { return "bash" }
+// BashTool creates a new bash tool with the specified configuration.
+// BashTool is a built-in tool that can be used to run shell commands.
+// See the [computer use guide](https://docs.anthropic.com/en/docs/agents-and-tools/computer-use) for more details.
+func BashTool(options ...BashToolOption) api.ProviderDefinedTool {
+	args := &BashToolArgs{
+		Version: DefaultToolVersion,
+	}
 
-// TextEditorTool is a built-in tool that can be used to view, create and edit text files.
+	for _, opt := range options {
+		opt(args)
+	}
+
+	return api.ProviderDefinedTool{
+		ID:   "anthropic.bash",
+		Name: "bash",
+		Args: args,
+	}
+}
+
+// TextEditorToolArgs contains the configuration arguments for the text editor tool.
 // See the [text editor guide](https://docs.anthropic.com/en/docs/build-with-claude/tool-use/text-editor-tool) for more details.
-type TextEditorTool struct {
+type TextEditorToolArgs struct {
 	// The version of the text editor tool to use.
 	// Optional field, defaults to the latest version. Possible values are: "20250124", "20241022".
 	Version string `json:"version"`
 }
 
-var _ api.ProviderDefinedTool = &TextEditorTool{}
+// TextEditorToolOption allows customizing text editor tool configuration.
+type TextEditorToolOption func(*TextEditorToolArgs)
 
-func (t *TextEditorTool) ToolType() string { return "provider-defined" }
-
-func (t *TextEditorTool) ID() string {
-	return "anthropic.text_editor"
+// WithTextEditorVersion sets the text editor tool version.
+func WithTextEditorVersion(version string) TextEditorToolOption {
+	return func(args *TextEditorToolArgs) {
+		args.Version = version
+	}
 }
 
-func (t *TextEditorTool) Name() string { return "str_replace_editor" }
+// TextEditorTool creates a new text editor tool with the specified configuration.
+// TextEditorTool is a built-in tool that can be used to view, create and edit text files.
+// See the [text editor guide](https://docs.anthropic.com/en/docs/build-with-claude/tool-use/text-editor-tool) for more details.
+func TextEditorTool(options ...TextEditorToolOption) api.ProviderDefinedTool {
+	args := &TextEditorToolArgs{
+		Version: DefaultToolVersion,
+	}
+
+	for _, opt := range options {
+		opt(args)
+	}
+
+	return api.ProviderDefinedTool{
+		ID:   "anthropic.text_editor",
+		Name: "str_replace_editor",
+		Args: args,
+	}
+}
 
 // TODO: Add predefined tool call blocks for the different built-in tools.

--- a/aisdk/ai/provider/anthropic/tools.go
+++ b/aisdk/ai/provider/anthropic/tools.go
@@ -2,11 +2,39 @@ package anthropic
 
 import "go.jetify.com/ai/provider/anthropic/codec"
 
-type (
-	ComputerUseTool  = codec.ComputerUseTool
-	ComputerToolCall = codec.ComputerToolCall
+// Factory functions for creating Anthropic tools
+var (
+	// ComputerTool creates a new computer use tool with the specified configuration.
+	ComputerTool = codec.ComputerTool
+
+	// BashTool creates a new bash tool with the specified configuration.
+	BashTool = codec.BashTool
+
+	// TextEditorTool creates a new text editor tool with the specified configuration.
+	TextEditorTool = codec.TextEditorTool
 )
 
-type BashTool = codec.BashTool
+// Option functions for customizing tools
+var (
+	// WithComputerVersion sets the computer tool version.
+	WithComputerVersion = codec.WithComputerVersion
 
-type TextEditorTool = codec.TextEditorTool
+	// WithDisplayNumber sets the display number for X11 environments.
+	WithDisplayNumber = codec.WithDisplayNumber
+
+	// WithBashVersion sets the bash tool version.
+	WithBashVersion = codec.WithBashVersion
+
+	// WithTextEditorVersion sets the text editor tool version.
+	WithTextEditorVersion = codec.WithTextEditorVersion
+)
+
+// Tool call types for handling responses
+type ComputerToolCall = codec.ComputerToolCall
+
+// Recommended constants
+const (
+	DefaultToolVersion       = codec.DefaultToolVersion
+	RecommendedDisplayWidth  = codec.RecommendedDisplayWidth
+	RecommendedDisplayHeight = codec.RecommendedDisplayHeight
+)

--- a/aisdk/ai/provider/openai/internal/codec/encode_tools.go
+++ b/aisdk/ai/provider/openai/internal/codec/encode_tools.go
@@ -113,12 +113,37 @@ func encodeFunctionTool(tool api.FunctionTool) (*responses.ToolUnionParam, []api
 	return &result, nil, nil
 }
 
+// convertArgs is a generic helper function that converts tool.Args to the expected struct type.
+// It handles both cases where Args is already the correct struct type or a map[string]any.
+func convertArgs[T any](args any) (*T, error) {
+	// Try direct type assertion first
+	if typedArgs, ok := args.(*T); ok {
+		return typedArgs, nil
+	}
+	if typedArgs, ok := args.(T); ok {
+		return &typedArgs, nil
+	}
+
+	// If that fails, try converting from map[string]any via JSON marshaling/unmarshaling
+	data, err := json.Marshal(args)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal args: %w", err)
+	}
+
+	var result T
+	if err := json.Unmarshal(data, &result); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal args to target type: %w", err)
+	}
+
+	return &result, nil
+}
+
 // encodeProviderDefinedTool encodes a provider-defined tool
 func encodeProviderDefinedTool(tool api.ProviderDefinedTool) (*responses.ToolUnionParam, []api.CallWarning, error) {
 	var result responses.ToolUnionParam
 	var err error
 
-	switch tool.ID() {
+	switch tool.ID {
 	case "openai.file_search":
 		result, err = encodeFileSearchTool(tool)
 		if err != nil {
@@ -165,19 +190,19 @@ func encodeProviderDefinedTool(tool api.ProviderDefinedTool) (*responses.ToolUni
 
 // encodeFileSearchTool creates a file search tool parameter
 func encodeFileSearchTool(tool api.ProviderDefinedTool) (responses.ToolUnionParam, error) {
-	fileSearchTool, ok := tool.(*FileSearchTool)
-	if !ok {
-		return responses.ToolUnionParam{}, fmt.Errorf("expected FileSearchTool but got %T", tool)
+	fileSearchArgs, err := convertArgs[FileSearchToolArgs](tool.Args)
+	if err != nil {
+		return responses.ToolUnionParam{}, fmt.Errorf("failed to convert file search tool args: %w", err)
 	}
 
-	return responses.ToolParamOfFileSearch(fileSearchTool.VectorStoreIDs), nil
+	return responses.ToolParamOfFileSearch(fileSearchArgs.VectorStoreIDs), nil
 }
 
 // encodeWebSearchTool creates a web search tool parameter
 func encodeWebSearchTool(tool api.ProviderDefinedTool) (responses.ToolUnionParam, error) {
-	webSearchTool, ok := tool.(*WebSearchTool)
-	if !ok {
-		return responses.ToolUnionParam{}, fmt.Errorf("expected WebSearchTool but got %T", tool)
+	webSearchArgs, err := convertArgs[WebSearchToolArgs](tool.Args)
+	if err != nil {
+		return responses.ToolUnionParam{}, fmt.Errorf("failed to convert web search tool args: %w", err)
 	}
 
 	// Create a web search tool param directly instead of using the helper function
@@ -185,28 +210,28 @@ func encodeWebSearchTool(tool api.ProviderDefinedTool) (responses.ToolUnionParam
 	webSearchParam.Type = responses.WebSearchToolTypeWebSearchPreview
 
 	// Set search context size if provided
-	if webSearchTool.SearchContextSize != "" {
-		webSearchParam.SearchContextSize = responses.WebSearchToolSearchContextSize(webSearchTool.SearchContextSize)
+	if webSearchArgs.SearchContextSize != "" {
+		webSearchParam.SearchContextSize = responses.WebSearchToolSearchContextSize(webSearchArgs.SearchContextSize)
 	}
 
 	// Set user location if provided
-	if webSearchTool.UserLocation != nil {
+	if webSearchArgs.UserLocation != nil {
 		userLocation := responses.WebSearchToolUserLocationParam{}
 
-		if webSearchTool.UserLocation.City != "" {
-			userLocation.City = openai.String(webSearchTool.UserLocation.City)
+		if webSearchArgs.UserLocation.City != "" {
+			userLocation.City = openai.String(webSearchArgs.UserLocation.City)
 		}
 
-		if webSearchTool.UserLocation.Country != "" {
-			userLocation.Country = openai.String(webSearchTool.UserLocation.Country)
+		if webSearchArgs.UserLocation.Country != "" {
+			userLocation.Country = openai.String(webSearchArgs.UserLocation.Country)
 		}
 
-		if webSearchTool.UserLocation.Region != "" {
-			userLocation.Region = openai.String(webSearchTool.UserLocation.Region)
+		if webSearchArgs.UserLocation.Region != "" {
+			userLocation.Region = openai.String(webSearchArgs.UserLocation.Region)
 		}
 
-		if webSearchTool.UserLocation.Timezone != "" {
-			userLocation.Timezone = openai.String(webSearchTool.UserLocation.Timezone)
+		if webSearchArgs.UserLocation.Timezone != "" {
+			userLocation.Timezone = openai.String(webSearchArgs.UserLocation.Timezone)
 		}
 
 		// Only set the UserLocation if at least one field was set
@@ -221,34 +246,34 @@ func encodeWebSearchTool(tool api.ProviderDefinedTool) (responses.ToolUnionParam
 
 // encodeComputerUseTool creates a computer use tool parameter
 func encodeComputerUseTool(tool api.ProviderDefinedTool) (responses.ToolUnionParam, error) {
-	computerUseTool, ok := tool.(*ComputerUseTool)
-	if !ok {
-		return responses.ToolUnionParam{}, fmt.Errorf("expected ComputerUseTool but got %T", tool)
+	computerArgs, err := convertArgs[ComputerUseToolArgs](tool.Args)
+	if err != nil {
+		return responses.ToolUnionParam{}, fmt.Errorf("failed to convert computer use tool args: %w", err)
 	}
 
 	// Validate required parameters
-	if computerUseTool.DisplayHeight <= 0 {
+	if computerArgs.DisplayHeight <= 0 {
 		return responses.ToolUnionParam{}, fmt.Errorf("displayHeight is required and must be positive")
 	}
 
-	if computerUseTool.DisplayWidth <= 0 {
+	if computerArgs.DisplayWidth <= 0 {
 		return responses.ToolUnionParam{}, fmt.Errorf("displayWidth is required and must be positive")
 	}
 
-	if computerUseTool.Environment == "" {
+	if computerArgs.Environment == "" {
 		return responses.ToolUnionParam{}, fmt.Errorf("environment is required")
 	}
 
 	// Validate that environment is one of the allowed values
-	env := computerUseTool.Environment
+	env := computerArgs.Environment
 	if env != "mac" && env != "windows" && env != "ubuntu" && env != "browser" {
 		return responses.ToolUnionParam{}, fmt.Errorf("environment must be one of: mac, windows, ubuntu, browser; got %q", env)
 	}
 
 	return responses.ToolParamOfComputerUsePreview(
-		int64(computerUseTool.DisplayHeight),
-		int64(computerUseTool.DisplayWidth),
-		responses.ComputerToolEnvironment(computerUseTool.Environment),
+		int64(computerArgs.DisplayHeight),
+		int64(computerArgs.DisplayWidth),
+		responses.ComputerToolEnvironment(computerArgs.Environment),
 	), nil
 }
 

--- a/aisdk/ai/provider/openai/internal/codec/encode_tools.go
+++ b/aisdk/ai/provider/openai/internal/codec/encode_tools.go
@@ -116,6 +116,10 @@ func encodeFunctionTool(tool api.FunctionTool) (*responses.ToolUnionParam, []api
 // convertArgs is a generic helper function that converts tool.Args to the expected struct type.
 // It handles both cases where Args is already the correct struct type or a map[string]any.
 func convertArgs[T any](args any) (*T, error) {
+	// Check if args is nil
+	if args == nil {
+		return nil, fmt.Errorf("args cannot be nil")
+	}
 	// Try direct type assertion first
 	if typedArgs, ok := args.(*T); ok {
 		return typedArgs, nil

--- a/aisdk/ai/provider/openai/internal/codec/tools.go
+++ b/aisdk/ai/provider/openai/internal/codec/tools.go
@@ -2,9 +2,9 @@ package codec
 
 import "go.jetify.com/ai/api"
 
-// FileSearchTool is a built-in tool that searches for relevant content from uploaded files.
+// FileSearchToolArgs is a built-in tool that searches for relevant content from uploaded files.
 // Learn more about the [file search tool](https://platform.openai.com/docs/guides/tools-file-search).
-type FileSearchTool struct {
+type FileSearchToolArgs struct {
 	// The IDs of the vector stores to search.
 	VectorStoreIDs []string `json:"vector_store_ids,omitzero"`
 
@@ -18,16 +18,6 @@ type FileSearchTool struct {
 	// // Ranking options for search.
 	// RankingOptions X `json:"ranking_options,omitzero"`
 }
-
-var _ api.ProviderDefinedTool = &FileSearchTool{}
-
-func (t *FileSearchTool) ToolType() string { return "provider-defined" }
-
-func (t *FileSearchTool) ID() string {
-	return "openai.file_search"
-}
-
-func (t *FileSearchTool) Name() string { return "file_search" }
 
 // FileSearchToolCall represents the results of a file search operation.
 // See the [file search guide](https://platform.openai.com/docs/guides/tools-file-search)
@@ -51,25 +41,50 @@ type FileSearchResult struct {
 	Text string `json:"text"`
 }
 
-// WebSearchTool is a built-in tool that searches the web for relevant results to use in a response.
+// FileSearchToolOption allows customizing file search tool configuration.
+type FileSearchToolOption func(*FileSearchToolArgs)
+
+// WithVectorStoreIDs sets the vector store IDs to search.
+func WithVectorStoreIDs(ids ...string) FileSearchToolOption {
+	return func(args *FileSearchToolArgs) {
+		args.VectorStoreIDs = ids
+	}
+}
+
+// WithMaxNumResults sets the maximum number of results to return.
+func WithMaxNumResults(maxResults int) FileSearchToolOption {
+	return func(args *FileSearchToolArgs) {
+		args.MaxNumResults = maxResults
+	}
+}
+
+// FileSearchTool creates a new file search tool with the specified configuration.
+// FileSearchTool is a built-in tool that searches for relevant content from uploaded files.
+// Learn more about the [file search tool](https://platform.openai.com/docs/guides/tools-file-search).
+func FileSearchTool(options ...FileSearchToolOption) api.ProviderDefinedTool {
+	args := &FileSearchToolArgs{}
+
+	// Apply options
+	for _, opt := range options {
+		opt(args)
+	}
+
+	return api.ProviderDefinedTool{
+		ID:   "openai.file_search",
+		Name: "file_search",
+		Args: args,
+	}
+}
+
+// WebSearchToolArgs is a built-in tool that searches the web for relevant results to use in a response.
 // Learn more about the [web search tool](https://platform.openai.com/docs/guides/tools-web-search).
-type WebSearchTool struct {
+type WebSearchToolArgs struct {
 	// High level guidance for the amount of context window space to use for the
 	// search. One of `low`, `medium`, or `high`. `medium` is the default.
 	SearchContextSize string `json:"search_context_size,omitempty"`
 	// User location information for geographically relevant results
 	UserLocation *WebSearchUserLocation `json:"user_location,omitempty"`
 }
-
-var _ api.ProviderDefinedTool = &WebSearchTool{}
-
-func (t *WebSearchTool) ToolType() string { return "provider-defined" }
-
-func (t *WebSearchTool) ID() string {
-	return "openai.web_search_preview"
-}
-
-func (t *WebSearchTool) Name() string { return "web_search_preview" }
 
 // WebSearchUserLocation represents the user location information for a web search
 type WebSearchUserLocation struct {
@@ -85,11 +100,46 @@ type WebSearchUserLocation struct {
 	Timezone string `json:"timezone,omitzero"`
 }
 
-// ComputerUseTool is a built-in tool that controls a virtual computer. Learn more about the
+// WebSearchToolOption allows customizing web search tool configuration.
+type WebSearchToolOption func(*WebSearchToolArgs)
+
+// WithSearchContextSize sets the search context size.
+func WithSearchContextSize(size string) WebSearchToolOption {
+	return func(args *WebSearchToolArgs) {
+		args.SearchContextSize = size
+	}
+}
+
+// WithUserLocation sets the user location for geographically relevant results.
+func WithUserLocation(location *WebSearchUserLocation) WebSearchToolOption {
+	return func(args *WebSearchToolArgs) {
+		args.UserLocation = location
+	}
+}
+
+// WebSearchTool creates a new web search tool with the specified configuration.
+// WebSearchTool is a built-in tool that searches the web for relevant results to use in a response.
+// Learn more about the [web search tool](https://platform.openai.com/docs/guides/tools-web-search).
+func WebSearchTool(options ...WebSearchToolOption) api.ProviderDefinedTool {
+	args := &WebSearchToolArgs{}
+
+	// Apply options
+	for _, opt := range options {
+		opt(args)
+	}
+
+	return api.ProviderDefinedTool{
+		ID:   "openai.web_search_preview",
+		Name: "web_search_preview",
+		Args: args,
+	}
+}
+
+// ComputerUseToolArgs is a built-in tool that controls a virtual computer. Learn more about the
 // [computer tool](https://platform.openai.com/docs/guides/tools-computer-use).
 //
 // The properties DisplayHeight, DisplayWidth, Environment, Type are required.
-type ComputerUseTool struct {
+type ComputerUseToolArgs struct {
 	// The height of the computer display.
 	DisplayHeight int `json:"display_height,omitempty"`
 	// The width of the computer display.
@@ -99,16 +149,6 @@ type ComputerUseTool struct {
 	// Any of "mac", "windows", "ubuntu", "browser".
 	Environment string `json:"environment,omitempty"`
 }
-
-var _ api.ProviderDefinedTool = &ComputerUseTool{}
-
-func (t *ComputerUseTool) ToolType() string { return "provider-defined" }
-
-func (t *ComputerUseTool) ID() string {
-	return "openai.computer_use_preview"
-}
-
-func (t *ComputerUseTool) Name() string { return "computer_use_preview" }
 
 // ComputerToolCall represents a computer-based tool operation.  See the
 // [computer use guide](https://platform.openai.com/docs/guides/tools-computer-use)
@@ -168,4 +208,44 @@ type ComputerSafetyCheck struct {
 	Code string
 	// Details about the pending safety check.
 	Message string
+}
+
+// ComputerUseToolOption allows customizing computer use tool configuration.
+type ComputerUseToolOption func(*ComputerUseToolArgs)
+
+// WithDisplaySize sets the display dimensions.
+func WithDisplaySize(width, height int) ComputerUseToolOption {
+	return func(args *ComputerUseToolArgs) {
+		args.DisplayWidth = width
+		args.DisplayHeight = height
+	}
+}
+
+// WithEnvironment sets the computer environment to control.
+func WithEnvironment(env string) ComputerUseToolOption {
+	return func(args *ComputerUseToolArgs) {
+		args.Environment = env
+	}
+}
+
+// ComputerUseTool creates a new computer use tool with the specified configuration.
+// ComputerUseTool is a built-in tool that controls a virtual computer. Learn more about the
+// [computer tool](https://platform.openai.com/docs/guides/tools-computer-use).
+func ComputerUseTool(displayWidth, displayHeight int, environment string, options ...ComputerUseToolOption) api.ProviderDefinedTool {
+	args := &ComputerUseToolArgs{
+		DisplayWidth:  displayWidth,
+		DisplayHeight: displayHeight,
+		Environment:   environment,
+	}
+
+	// Apply options
+	for _, opt := range options {
+		opt(args)
+	}
+
+	return api.ProviderDefinedTool{
+		ID:   "openai.computer_use_preview",
+		Name: "computer_use_preview",
+		Args: args,
+	}
 }

--- a/aisdk/ai/provider/openai/llm_test.go
+++ b/aisdk/ai/provider/openai/llm_test.go
@@ -1083,12 +1083,12 @@ func TestGenerate(t *testing.T) {
 			prompt:  standardPrompt,
 			options: api.CallOptions{
 				Tools: []api.ToolDefinition{
-					&codec.WebSearchTool{
-						SearchContextSize: "high",
-						UserLocation: &codec.WebSearchUserLocation{
+					WebSearchTool(
+						WithSearchContextSize("high"),
+						WithUserLocation(&WebSearchUserLocation{
 							City: "San Francisco",
-						},
-					},
+						}),
+					),
 				},
 			},
 			exchanges: []httpmock.Exchange{
@@ -1144,12 +1144,12 @@ func TestGenerate(t *testing.T) {
 					ToolName: "web_search_preview",
 				},
 				Tools: []api.ToolDefinition{
-					&codec.WebSearchTool{
-						SearchContextSize: "high",
-						UserLocation: &codec.WebSearchUserLocation{
+					WebSearchTool(
+						WithSearchContextSize("high"),
+						WithUserLocation(&WebSearchUserLocation{
 							City: "San Francisco",
-						},
-					},
+						}),
+					),
 				},
 			},
 			exchanges: []httpmock.Exchange{
@@ -1586,12 +1586,12 @@ func TestGenerate_WebSearch(t *testing.T) {
 			exchanges: standardExchange,
 			options: api.CallOptions{
 				Tools: []api.ToolDefinition{
-					&codec.WebSearchTool{
-						SearchContextSize: "medium",
-						UserLocation: &codec.WebSearchUserLocation{
+					WebSearchTool(
+						WithSearchContextSize("medium"),
+						WithUserLocation(&WebSearchUserLocation{
 							Country: "US",
-						},
-					},
+						}),
+					),
 				},
 			},
 			expectedResp: api.Response{
@@ -1611,12 +1611,12 @@ func TestGenerate_WebSearch(t *testing.T) {
 			exchanges: standardExchange,
 			options: api.CallOptions{
 				Tools: []api.ToolDefinition{
-					&codec.WebSearchTool{
-						SearchContextSize: "medium",
-						UserLocation: &codec.WebSearchUserLocation{
+					WebSearchTool(
+						WithSearchContextSize("medium"),
+						WithUserLocation(&WebSearchUserLocation{
 							Country: "US",
-						},
-					},
+						}),
+					),
 				},
 			},
 			expectedResp: api.Response{
@@ -2401,12 +2401,12 @@ func TestStream(t *testing.T) {
 			prompt:  standardPrompt,
 			options: api.CallOptions{
 				Tools: []api.ToolDefinition{
-					&codec.WebSearchTool{
-						SearchContextSize: "medium",
-						UserLocation: &codec.WebSearchUserLocation{
+					WebSearchTool(
+						WithSearchContextSize("medium"),
+						WithUserLocation(&WebSearchUserLocation{
 							Country: "US",
-						},
-					},
+						}),
+					),
 				},
 			},
 			exchanges: []httpmock.Exchange{

--- a/aisdk/ai/provider/openai/tools.go
+++ b/aisdk/ai/provider/openai/tools.go
@@ -1,19 +1,55 @@
 package openai
 
-import "go.jetify.com/ai/provider/openai/internal/codec"
-
-type (
-	FileSearchTool     = codec.FileSearchTool
-	FileSearchToolCall = codec.FileSearchToolCall
-	FileSearchResult   = codec.FileSearchResult
+import (
+	"go.jetify.com/ai/provider/openai/internal/codec"
 )
 
+// Tool structs and related types for direct access
 type (
-	WebSearchTool         = codec.WebSearchTool
+	// Args structs for tool configuration
+	FileSearchToolArgs  = codec.FileSearchToolArgs
+	WebSearchToolArgs   = codec.WebSearchToolArgs
+	ComputerUseToolArgs = codec.ComputerUseToolArgs
+
+	// Tool call result structs
+	FileSearchToolCall  = codec.FileSearchToolCall
+	FileSearchResult    = codec.FileSearchResult
+	ComputerToolCall    = codec.ComputerToolCall
+	ComputerCoordinates = codec.ComputerCoordinates
+	ComputerSafetyCheck = codec.ComputerSafetyCheck
+
+	// User location for web search
 	WebSearchUserLocation = codec.WebSearchUserLocation
+
+	// Option types for customization
+	FileSearchToolOption  = codec.FileSearchToolOption
+	WebSearchToolOption   = codec.WebSearchToolOption
+	ComputerUseToolOption = codec.ComputerUseToolOption
 )
 
-type (
-	ComputerUseTool  = codec.ComputerUseTool
-	ComputerToolCall = codec.ComputerToolCall
+// Constructor functions for creating tools
+var (
+	// FileSearchTool creates a new file search tool with the specified configuration.
+	FileSearchTool = codec.FileSearchTool
+
+	// WebSearchTool creates a new web search tool with the specified configuration.
+	WebSearchTool = codec.WebSearchTool
+
+	// ComputerUseTool creates a new computer use tool with the specified configuration.
+	ComputerUseTool = codec.ComputerUseTool
+)
+
+// Option functions for tool customization
+var (
+	// File search options
+	WithVectorStoreIDs = codec.WithVectorStoreIDs
+	WithMaxNumResults  = codec.WithMaxNumResults
+
+	// Web search options
+	WithSearchContextSize = codec.WithSearchContextSize
+	WithUserLocation      = codec.WithUserLocation
+
+	// Computer use options
+	WithDisplaySize = codec.WithDisplaySize
+	WithEnvironment = codec.WithEnvironment
 )


### PR DESCRIPTION

## Summary
This PR makes it possible to marshal and unmarshall CallOptions to/from JSON. In particular, I had to change ProvderDefinedTool from an interface to a concrete type so that it could be appropriately serialized.

Details:
- Add custom JSON unmarshaling for CallOptions to handle polymorphic ToolDefinition interface
- Add JSON unmarshaling for ProviderMetadata
- Implement automatic "type" field inclusion for FunctionTool and ProviderDefinedTool JSON marshaling
- Refactor Anthropic provider to use generic convertArgs helper for flexible tool argument conversion
- Support both struct-based and map[string]any tool arguments
- Add comprehensive tests for JSON marshaling/unmarshaling

## How was it tested?
Wrote unit test for json serialization, updated existing tests appropriately.

## Community Contribution License

All community contributions in this pull request are licensed to the project maintainers under the terms of the [Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request I represent that I have the right to license the contributions to the project maintainers under the Apache 2 License as stated in the [Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).
