### PR TITLE
aisdk: move to github.com/google/jsonschema-go/jsonschema

### DIFF
--- a/aisdk/ai/api/jsonschema_helpers.go
+++ b/aisdk/ai/api/jsonschema_helpers.go
@@ -1,7 +1,7 @@
 package api
 
 import (
-	"github.com/modelcontextprotocol/go-sdk/jsonschema"
+	"github.com/google/jsonschema-go/jsonschema"
 )
 
 // FalseSchema returns a new Schema that fails to validate any value.

--- a/aisdk/ai/api/llm_call_options.go
+++ b/aisdk/ai/api/llm_call_options.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/modelcontextprotocol/go-sdk/jsonschema"
+	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/tidwall/gjson"
 )
 

--- a/aisdk/ai/api/llm_call_options_test.go
+++ b/aisdk/ai/api/llm_call_options_test.go
@@ -54,7 +54,7 @@ func TestCallOptions_JSON(t *testing.T) {
 							"age": {"type": "integer"}
 						},
 						"required": ["name"],
-						"additionalProperties": {"not": {}}
+						"additionalProperties": false
 					},
 					"name": "user_info",
 					"description": "User information structure"
@@ -72,7 +72,7 @@ func TestCallOptions_JSON(t *testing.T) {
 								"units": {"type": "string", "enum": ["metric", "imperial"]}
 							},
 							"required": ["location"],
-							"additionalProperties": {"not": {}}
+							"additionalProperties": false
 						}
 					},
 					{

--- a/aisdk/ai/api/llm_tool.go
+++ b/aisdk/ai/api/llm_tool.go
@@ -3,7 +3,7 @@ package api
 import (
 	"encoding/json"
 
-	"github.com/modelcontextprotocol/go-sdk/jsonschema"
+	"github.com/google/jsonschema-go/jsonschema"
 )
 
 // ToolChoice specifies how tools should be selected by the model.

--- a/aisdk/ai/go.mod
+++ b/aisdk/ai/go.mod
@@ -4,8 +4,8 @@ go 1.24.0
 
 require (
 	github.com/anthropics/anthropic-sdk-go v1.9.1
+	github.com/google/jsonschema-go v0.2.0
 	github.com/k0kubun/pp/v3 v3.5.0
-	github.com/modelcontextprotocol/go-sdk v0.2.0
 	github.com/openai/openai-go/v2 v2.0.2
 	github.com/stretchr/testify v1.10.0
 	github.com/tidwall/gjson v1.18.0

--- a/aisdk/ai/go.sum
+++ b/aisdk/ai/go.sum
@@ -5,6 +5,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/jsonschema-go v0.2.0 h1:Uh19091iHC56//WOsAd1oRg6yy1P9BpSvpjOL6RcjLQ=
+github.com/google/jsonschema-go v0.2.0/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/k0kubun/pp/v3 v3.5.0 h1:iYNlYA5HJAJvkD4ibuf9c8y6SHM0QFhaBuCqm1zHp0w=
 github.com/k0kubun/pp/v3 v3.5.0/go.mod h1:5lzno5ZZeEeTV/Ky6vs3g6d1U3WarDrH8k240vMtGro=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
@@ -15,8 +17,6 @@ github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHP
 github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
-github.com/modelcontextprotocol/go-sdk v0.2.0 h1:PESNYOmyM1c369tRkzXLY5hHrazj8x9CY1Xu0fLCryM=
-github.com/modelcontextprotocol/go-sdk v0.2.0/go.mod h1:0sL9zUKKs2FTTkeCCVnKqbLJTw5TScefPAzojjU459E=
 github.com/openai/openai-go/v2 v2.0.2 h1:DlB9pnhhSRm2NuQNijB3j2U8fhDSk3sFX9ULK5hUs0o=
 github.com/openai/openai-go/v2 v2.0.2/go.mod h1:sIUkR+Cu/PMUVkSKhkk742PRURkQOCFhiwJ7eRSBqmk=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/aisdk/ai/options_test.go
+++ b/aisdk/ai/options_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/modelcontextprotocol/go-sdk/jsonschema"
+	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/stretchr/testify/assert"
 	"go.jetify.com/ai/api"
 	"go.jetify.com/pkg/pointer"

--- a/aisdk/ai/provider/anthropic/codec/encode_tools_test.go
+++ b/aisdk/ai/provider/anthropic/codec/encode_tools_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/anthropics/anthropic-sdk-go"
-	"github.com/modelcontextprotocol/go-sdk/jsonschema"
+	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.jetify.com/ai/api"

--- a/aisdk/ai/provider/anthropic/codec/jsonschema.go
+++ b/aisdk/ai/provider/anthropic/codec/jsonschema.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/anthropics/anthropic-sdk-go"
-	"github.com/modelcontextprotocol/go-sdk/jsonschema"
+	"github.com/google/jsonschema-go/jsonschema"
 )
 
 // encodeSchema converts a jsonschema.Schema to map[string]any for Anthropic API.

--- a/aisdk/ai/provider/anthropic/codec/jsonschema_test.go
+++ b/aisdk/ai/provider/anthropic/codec/jsonschema_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/modelcontextprotocol/go-sdk/jsonschema"
+	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.jetify.com/ai/api"

--- a/aisdk/ai/provider/openai/internal/codec/encode_tools_test.go
+++ b/aisdk/ai/provider/openai/internal/codec/encode_tools_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/modelcontextprotocol/go-sdk/jsonschema"
+	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.jetify.com/ai/api"

--- a/aisdk/ai/provider/openai/internal/codec/jsonschema.go
+++ b/aisdk/ai/provider/openai/internal/codec/jsonschema.go
@@ -1,10 +1,11 @@
 package codec
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 
-	"github.com/modelcontextprotocol/go-sdk/jsonschema"
+	"github.com/google/jsonschema-go/jsonschema"
 )
 
 // encodeSchema converts a jsonschema.Schema to a map representation suitable for OpenAI API.
@@ -21,9 +22,14 @@ func encodeSchema(schema *jsonschema.Schema) (map[string]any, error) {
 		return nil, fmt.Errorf("failed to marshal properties: %w", err)
 	}
 
-	var result map[string]interface{}
+	// Convert the schema "false" back to an empty object.
+	if bytes.Equal(data, []byte("true")) {
+		return make(map[string]any), nil
+	}
+
+	var result map[string]any
 	if err := json.Unmarshal(data, &result); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal properties: %w", err)
+		return nil, fmt.Errorf("failed to unmarshal properties: %w\n\n%s", err, data)
 	}
 
 	// Convert {"not": {}} patterns to false throughout the schema
@@ -35,14 +41,14 @@ func encodeSchema(schema *jsonschema.Schema) (map[string]any, error) {
 // normalizeSchemaMap recursively converts {"not": {}} to false in a schema map.
 // This is needed because OpenAI expects "additionalProperties": false
 // but MCP jsonschema represents false as {"not": {}}
-func normalizeSchemaMap(schemaMap map[string]interface{}) {
+func normalizeSchemaMap(schemaMap map[string]any) {
 	for key, value := range schemaMap {
 		switch v := value.(type) {
-		case map[string]interface{}:
+		case map[string]any:
 			// Check if this is a {"not": {}} pattern
 			if key == "additionalProperties" && len(v) == 1 {
 				if not, hasNot := v["not"]; hasNot {
-					if notMap, isMap := not.(map[string]interface{}); isMap && len(notMap) == 0 {
+					if notMap, isMap := not.(map[string]any); isMap && len(notMap) == 0 {
 						schemaMap[key] = false
 						continue
 					}
@@ -50,10 +56,10 @@ func normalizeSchemaMap(schemaMap map[string]interface{}) {
 			}
 			// Recursively process nested objects
 			normalizeSchemaMap(v)
-		case []interface{}:
+		case []any:
 			// Process arrays of schemas
 			for _, item := range v {
-				if itemMap, ok := item.(map[string]interface{}); ok {
+				if itemMap, ok := item.(map[string]any); ok {
 					normalizeSchemaMap(itemMap)
 				}
 			}

--- a/aisdk/ai/provider/openai/internal/codec/jsonschema_test.go
+++ b/aisdk/ai/provider/openai/internal/codec/jsonschema_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/modelcontextprotocol/go-sdk/jsonschema"
+	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.jetify.com/ai/api"

--- a/aisdk/ai/provider/openai/llm_test.go
+++ b/aisdk/ai/provider/openai/llm_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/modelcontextprotocol/go-sdk/jsonschema"
+	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/openai/openai-go/v2"
 	"github.com/openai/openai-go/v2/option"
 	"github.com/stretchr/testify/require"

--- a/go.work.sum
+++ b/go.work.sum
@@ -164,6 +164,7 @@ github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mattn/go-runewidth v0.0.12/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
+github.com/modelcontextprotocol/go-sdk v0.2.0/go.mod h1:0sL9zUKKs2FTTkeCCVnKqbLJTw5TScefPAzojjU459E=
 github.com/muesli/reflow v0.3.0 h1:IFsN6K9NfGtjeggFP+68I4chLZV2yIKsXJFNZ+eWh6s=
 github.com/muesli/reflow v0.3.0/go.mod h1:pbwTDkVPibjO2kyvBQRBxTWEEGDGq0FlB1BIKtnHY/8=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=


### PR DESCRIPTION
The github.com/modelcontextprotocol/go-sdk/jsonschema package was moved to github.com/google/jsonschema-go/jsonschema.

Breaking changes from jsonschema:

- It now marshals `additionalProperties: {"not":{}}` as `false`.
- The empty schema marshals to `false`. Convert it back to an empty object, since I'm not sure what the OpenAI API allows.