### PR TITLE
Add a mock LanguageModel to the AI SDK

### DIFF
--- a/aisdk/ai/provider/mock/mock.go
+++ b/aisdk/ai/provider/mock/mock.go
@@ -1,0 +1,138 @@
+// Package mock provides mock implementations for testing.
+//
+// Example usage:
+//
+//	mock := mock.NewGenerateModel([]mock.MockResult{
+//		{Response: api.Response{Text: "Hello"}},
+//		{Error: errors.New("rate limit exceeded")},
+//		{Response: api.Response{Text: "World"}},
+//	})
+//
+//	// First call returns success
+//	resp1, err1 := mock.Generate(ctx, messages, opts) // returns "Hello", nil
+//
+//	// Second call returns error
+//	resp2, err2 := mock.Generate(ctx, messages, opts) // returns {}, error
+//
+//	// Third call returns success
+//	resp3, err3 := mock.Generate(ctx, messages, opts) // returns "World", nil
+//
+//	// Verify all expectations were met
+//	mock.AssertCount(t)
+package mock
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+
+	"github.com/stretchr/testify/assert"
+	"go.jetify.com/ai/api"
+)
+
+// MockResult represents either a successful response or an error
+type MockResult struct {
+	Response *api.Response
+	Error    error
+}
+
+type GenerateModel struct {
+	results         []MockResult
+	callCount       atomic.Int32
+	streamCallCount atomic.Int32
+	providerName    string
+	modelID         string
+}
+
+// T is an interface that captures the testing.T methods we need
+type T interface {
+	Errorf(format string, args ...any)
+	FailNow()
+	Helper()
+}
+
+// GenerateModelOption is a functional option for configuring a GenerateModel
+type GenerateModelOption func(*GenerateModel)
+
+// WithProviderName sets the provider name for the mock model
+func WithProviderName(name string) GenerateModelOption {
+	return func(m *GenerateModel) {
+		m.providerName = name
+	}
+}
+
+// WithModelID sets the model ID for the mock model
+func WithModelID(id string) GenerateModelOption {
+	return func(m *GenerateModel) {
+		m.modelID = id
+	}
+}
+
+// NewGenerateModel creates a new mock GenerateModel with the given results.
+// The results will be returned in order as Generate is called.
+// If results is nil, it will be treated as an empty slice.
+// Optional functional options can be provided to customize provider name and model ID.
+func NewGenerateModel(results []MockResult, opts ...GenerateModelOption) *GenerateModel {
+	if results == nil {
+		results = []MockResult{}
+	}
+
+	m := &GenerateModel{
+		results:      results,
+		providerName: "mock-provider", // Default
+		modelID:      "mock-model",    // Default
+	}
+
+	// Apply options
+	for _, opt := range opts {
+		opt(m)
+	}
+
+	return m
+}
+
+func (m *GenerateModel) ProviderName() string {
+	return m.providerName
+}
+
+func (m *GenerateModel) ModelID() string {
+	return m.modelID
+}
+
+func (m *GenerateModel) SupportedUrls() []api.SupportedURL {
+	return nil
+}
+
+func (m *GenerateModel) Generate(
+	ctx context.Context, prompt []api.Message, opts api.CallOptions,
+) (*api.Response, error) {
+	// Atomically increment and get the new count
+	newCount := m.callCount.Add(1)
+	index := newCount - 1
+
+	if int(index) < len(m.results) {
+		result := m.results[index]
+		return result.Response, result.Error
+	}
+	return &api.Response{}, nil
+}
+
+func (m *GenerateModel) Stream(
+	ctx context.Context, prompt []api.Message, opts api.CallOptions,
+) (*api.StreamResponse, error) {
+	m.streamCallCount.Add(1)
+	return nil, errors.New("Stream: not implemented")
+}
+
+// AssertCount verifies that all expected results have been consumed
+// and that Stream was never called.
+// It fails the test if there are unused results or if Stream was called.
+func (m *GenerateModel) AssertCount(t T) {
+	t.Helper()
+	callCount := int(m.callCount.Load())
+	streamCallCount := int(m.streamCallCount.Load())
+	assert.Equal(t, len(m.results), callCount,
+		"GenerateModel: expected %d Generate calls, but got %d", len(m.results), callCount)
+	assert.Equal(t, 0, streamCallCount,
+		"GenerateModel: expected 0 Stream calls, but got %d", streamCallCount)
+}

--- a/aisdk/ai/provider/mock/mock.go
+++ b/aisdk/ai/provider/mock/mock.go
@@ -3,9 +3,9 @@
 // Example usage:
 //
 //	mock := mock.NewGenerateModel([]mock.MockResult{
-//		{Response: api.Response{Text: "Hello"}},
+//		{Response: &api.Response{Content: []api.ContentBlock{&api.TextBlock{Text: "Hello"}}}},
 //		{Error: errors.New("rate limit exceeded")},
-//		{Response: api.Response{Text: "World"}},
+//		{Response: &api.Response{Content: []api.ContentBlock{&api.TextBlock{Text: "World"}}}},
 //	})
 //
 //	// First call returns success

--- a/aisdk/ai/provider/mock/mock_test.go
+++ b/aisdk/ai/provider/mock/mock_test.go
@@ -1,0 +1,241 @@
+package mock
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.jetify.com/ai/api"
+)
+
+func TestGenerateModel(t *testing.T) {
+	ctx := context.Background()
+	messages := []api.Message{
+		&api.UserMessage{Content: []api.ContentBlock{&api.TextBlock{Text: "test"}}},
+	}
+	opts := api.CallOptions{}
+
+	tests := []struct {
+		name    string
+		results []MockResult
+	}{
+		{
+			name: "single successful result",
+			results: []MockResult{
+				{Response: &api.Response{
+					Content: []api.ContentBlock{&api.TextBlock{Text: "Success"}},
+				}},
+			},
+		},
+		{
+			name: "single error result",
+			results: []MockResult{
+				{Error: errors.New("rate limit exceeded")},
+			},
+		},
+		{
+			name: "multiple results in order",
+			results: []MockResult{
+				{Response: &api.Response{
+					Content: []api.ContentBlock{&api.TextBlock{Text: "First"}},
+				}},
+				{Error: errors.New("second fails")},
+				{Response: &api.Response{
+					Content: []api.ContentBlock{&api.TextBlock{Text: "Third"}},
+				}},
+			},
+		},
+		{
+			name: "multiple successful results",
+			results: []MockResult{
+				{Response: &api.Response{
+					Content: []api.ContentBlock{&api.TextBlock{Text: "First"}},
+				}},
+				{Response: &api.Response{
+					Content: []api.ContentBlock{&api.TextBlock{Text: "Second"}},
+				}},
+				{Response: &api.Response{
+					Content: []api.ContentBlock{&api.TextBlock{Text: "Third"}},
+				}},
+			},
+		},
+		{
+			name: "multiple error results",
+			results: []MockResult{
+				{Error: errors.New("first error")},
+				{Error: errors.New("second error")},
+				{Error: errors.New("third error")},
+			},
+		},
+		{
+			name:    "empty results slice",
+			results: []MockResult{},
+		},
+		{
+			name:    "nil results",
+			results: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			model := NewGenerateModel(test.results)
+
+			// Accumulate responses
+			var accumulated []MockResult
+			if test.results != nil {
+				accumulated = make([]MockResult, 0, len(test.results))
+			}
+
+			// Check AssertCount before any calls
+			mockT := &mockTestingT{}
+			model.AssertCount(mockT)
+			if len(test.results) == 0 {
+				assert.False(t, mockT.failed, "AssertCount should have passed with 0 calls when expecting 0 results")
+			} else {
+				assert.True(t, mockT.failed, "AssertCount should have failed with 0 calls when expecting %d results", len(test.results))
+			}
+
+			// Call Generate() len(results) + 1 times
+			totalCalls := len(test.results) + 1
+			for i := 0; i < totalCalls; i++ {
+				resp, err := model.Generate(ctx, messages, opts)
+
+				// Accumulate results up to len(results)
+				if i < len(test.results) {
+					accumulated = append(accumulated, MockResult{
+						Response: resp,
+						Error:    err,
+					})
+				}
+
+				// Check AssertCount after each call
+				mockT = &mockTestingT{}
+				model.AssertCount(mockT)
+
+				// Should pass only when we've made exactly len(results) calls
+				// i+1 is the number of calls made so far
+				if i+1 == len(test.results) {
+					assert.False(t, mockT.failed, "AssertCount should have passed at call %d (exactly %d results)", i+1, len(test.results))
+				} else {
+					assert.True(t, mockT.failed, "AssertCount should have failed at call %d (expected %d results)", i+1, len(test.results))
+				}
+			}
+
+			// Compare accumulated results with original
+			assert.Equal(t, test.results, accumulated)
+		})
+	}
+}
+
+func TestStreamCallTracking(t *testing.T) {
+	ctx := context.Background()
+	messages := []api.Message{
+		&api.UserMessage{Content: []api.ContentBlock{&api.TextBlock{Text: "test"}}},
+	}
+	opts := api.CallOptions{}
+
+	t.Run("AssertCount fails when Stream is called", func(t *testing.T) {
+		model := NewGenerateModel([]MockResult{})
+
+		// Call Stream method
+		_, err := model.Stream(ctx, messages, opts)
+		assert.Error(t, err, "Stream should return an error")
+		assert.Contains(t, err.Error(), "not implemented", "Stream should return 'not implemented' error")
+
+		// AssertCount should fail because Stream was called
+		mockT := &mockTestingT{}
+		model.AssertCount(mockT)
+		assert.True(t, mockT.failed, "AssertCount should fail when Stream was called")
+	})
+
+	t.Run("AssertCount passes when Stream is never called", func(t *testing.T) {
+		model := NewGenerateModel([]MockResult{})
+
+		// Don't call Stream, only check AssertCount
+		mockT := &mockTestingT{}
+		model.AssertCount(mockT)
+		assert.False(t, mockT.failed, "AssertCount should pass when Stream was never called")
+	})
+
+	t.Run("AssertCount fails when Stream is called even with correct Generate calls", func(t *testing.T) {
+		model := NewGenerateModel([]MockResult{
+			{Response: &api.Response{Content: []api.ContentBlock{&api.TextBlock{Text: "test"}}}},
+		})
+
+		// Make the expected Generate call
+		_, err := model.Generate(ctx, messages, opts)
+		assert.NoError(t, err)
+
+		// Also call Stream
+		_, err = model.Stream(ctx, messages, opts)
+		assert.Error(t, err)
+
+		// AssertCount should fail because Stream was called, even though Generate calls match
+		mockT := &mockTestingT{}
+		model.AssertCount(mockT)
+		assert.True(t, mockT.failed, "AssertCount should fail when Stream was called, even with correct Generate calls")
+	})
+}
+
+// mockTestingT implements the mock.T interface for testing
+type mockTestingT struct {
+	failed bool
+}
+
+func (m *mockTestingT) Errorf(format string, args ...any) {
+	m.failed = true
+}
+
+func (m *mockTestingT) FailNow() {
+	m.failed = true
+}
+
+func (m *mockTestingT) Helper() {}
+
+func TestGenerateModelOptions(t *testing.T) {
+	tests := []struct {
+		name         string
+		opts         []GenerateModelOption
+		wantProvider string
+		wantModelID  string
+	}{
+		{
+			name:         "default values",
+			opts:         nil,
+			wantProvider: "mock-provider",
+			wantModelID:  "mock-model",
+		},
+		{
+			name:         "custom provider only",
+			opts:         []GenerateModelOption{WithProviderName("custom-provider")},
+			wantProvider: "custom-provider",
+			wantModelID:  "mock-model",
+		},
+		{
+			name:         "custom model ID only",
+			opts:         []GenerateModelOption{WithModelID("custom-model")},
+			wantProvider: "mock-provider",
+			wantModelID:  "custom-model",
+		},
+		{
+			name: "both custom provider and model ID",
+			opts: []GenerateModelOption{
+				WithProviderName("openai"),
+				WithModelID("gpt-4"),
+			},
+			wantProvider: "openai",
+			wantModelID:  "gpt-4",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			model := NewGenerateModel([]MockResult{}, test.opts...)
+
+			assert.Equal(t, test.wantProvider, model.ProviderName())
+			assert.Equal(t, test.wantModelID, model.ModelID())
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Adds a `mock` Language Model to the AI SDK that is useful for testing.

## How was it tested?
Added unit test.

## Community Contribution License

All community contributions in this pull request are licensed to the project maintainers under the terms of the [Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request I represent that I have the right to license the contributions to the project maintainers under the Apache 2 License as stated in the [Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).
