### PR TITLE
[httpmock] Ignore additional headers

### DIFF
--- a/pkg/httpmock/replay_test.go
+++ b/pkg/httpmock/replay_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -160,6 +161,154 @@ func TestFormatRequestBody(t *testing.T) {
 	}
 }
 
+func TestReplayServerAdditionalIgnoredHeaders(t *testing.T) {
+	tests := []struct {
+		name                     string
+		additionalIgnoredHeaders []string
+		requestHeaders           map[string]string
+		responseHeaders          map[string]string
+		expectedInCassette       struct {
+			requestHeaders  map[string]string
+			responseHeaders map[string]string
+		}
+	}{
+		{
+			name: "additional_ignored_headers",
+			additionalIgnoredHeaders: []string{
+				"X-Request-ID",
+				"X-Trace-ID",
+				"X-Response-ID",
+			},
+			requestHeaders: map[string]string{
+				"Authorization": "Bearer token123",  // Default ignored
+				"X-Request-ID":  "req-123",          // Additional ignored
+				"X-Trace-ID":    "trace-456",        // Additional ignored
+				"Content-Type":  "application/json", // Should be preserved
+			},
+			responseHeaders: map[string]string{
+				"Set-Cookie":    "session=abc123", // Default ignored
+				"X-Response-ID": "resp-789",       // Additional ignored
+				"Server":        "test-server",    // Should be preserved
+			},
+			expectedInCassette: struct {
+				requestHeaders  map[string]string
+				responseHeaders map[string]string
+			}{
+				requestHeaders: map[string]string{
+					"Content-Type": "application/json",
+				},
+				responseHeaders: map[string]string{
+					"Server":       "test-server",
+					"Content-Type": "text/plain; charset=utf-8", // Auto-added by Go HTTP server
+					// Note: Date header is also auto-added but varies, so we'll handle it separately
+				},
+			},
+		},
+		{
+			name:                     "no_additional_ignored_headers",
+			additionalIgnoredHeaders: []string{}, // No additional headers
+			requestHeaders: map[string]string{
+				"Authorization": "Bearer token123",  // Default ignored
+				"X-Custom":      "custom-value",     // Should be preserved
+				"Content-Type":  "application/json", // Should be preserved
+			},
+			responseHeaders: map[string]string{
+				"Set-Cookie": "session=abc123", // Default ignored
+				"X-Custom":   "response-value", // Should be preserved
+			},
+			expectedInCassette: struct {
+				requestHeaders  map[string]string
+				responseHeaders map[string]string
+			}{
+				requestHeaders: map[string]string{
+					"X-Custom":     "custom-value",
+					"Content-Type": "application/json",
+				},
+				responseHeaders: map[string]string{
+					"X-Custom":     "response-value",
+					"Content-Type": "text/plain; charset=utf-8", // Auto-added by Go HTTP server
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Create a test server that returns the configured response headers
+			testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				for header, value := range test.responseHeaders {
+					w.Header().Set(header, value)
+				}
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(`{"status": "ok"}`))
+			}))
+			defer testServer.Close()
+
+			cassetteName := "testdata/server_" + test.name
+
+			// Create replay server with additional ignored headers
+			replayServer := NewReplayServer(t, ReplayConfig{
+				Host:                     testServer.URL,
+				Cassette:                 cassetteName,
+				AdditionalIgnoredHeaders: test.additionalIgnoredHeaders,
+			})
+
+			// Make request with the configured headers
+			req, err := buildRequest(replayServer.URL(), Request{
+				Method:  http.MethodGet,
+				Path:    "/test",
+				Headers: test.requestHeaders,
+			})
+			require.NoError(t, err)
+
+			// Make the request
+			resp, err := http.DefaultClient.Do(req)
+			require.NoError(t, err)
+			resp.Body.Close()
+
+			// Close server to ensure cassette is saved
+			replayServer.Close()
+
+			// Load and inspect the cassette
+			cassette, err := cassette.Load(cassetteName)
+			require.NoError(t, err)
+			require.Len(t, cassette.Interactions, 1, "should have exactly one interaction")
+
+			interaction := cassette.Interactions[0]
+
+			// Verify request headers: cassette should contain exactly the expected headers
+			for header, expectedValue := range test.expectedInCassette.requestHeaders {
+				assert.Equal(t, expectedValue, interaction.Request.Headers.Get(header),
+					"request header %q should be preserved in cassette", header)
+			}
+			// Verify no unexpected request headers are present
+			for header := range interaction.Request.Headers {
+				if _, expected := test.expectedInCassette.requestHeaders[header]; !expected {
+					assert.Empty(t, interaction.Request.Headers.Get(header),
+						"unexpected request header %q found in cassette", header)
+				}
+			}
+
+			// Verify response headers: cassette should contain exactly the expected headers
+			for header, expectedValue := range test.expectedInCassette.responseHeaders {
+				assert.Equal(t, expectedValue, interaction.Response.Headers.Get(header),
+					"response header %q should be preserved in cassette", header)
+			}
+			// Verify no unexpected response headers are present (except for auto-generated ones like Date)
+			for header := range interaction.Response.Headers {
+				if _, expected := test.expectedInCassette.responseHeaders[header]; !expected {
+					// Allow certain headers that are automatically added by Go's HTTP server
+					if header == "Date" {
+						continue // Date header is auto-generated and varies
+					}
+					assert.Empty(t, interaction.Response.Headers.Get(header),
+						"unexpected response header %q found in cassette", header)
+				}
+			}
+		})
+	}
+}
+
 func TestRemoveIgnored(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -226,7 +375,7 @@ func TestRemoveIgnored(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err := removeIgnored(test.interaction)
+			err := removeIgnoredHeaders(test.interaction, ignoredHeaders)
 			assert.NoError(t, err)
 
 			// Check request headers

--- a/pkg/httpmock/testdata/server_additional_ignored_headers.yaml
+++ b/pkg/httpmock/testdata/server_additional_ignored_headers.yaml
@@ -1,0 +1,33 @@
+---
+version: 2
+interactions:
+- id: 0
+  request:
+    proto: HTTP/1.1
+    proto_major: 1
+    proto_minor: 1
+    content_length: 4
+    host: 127.0.0.1:52807
+    request_uri: /test
+    body: "null"
+    headers:
+      Content-Type:
+      - application/json
+    url: http://127.0.0.1:52807/test
+    method: GET
+  response:
+    proto: HTTP/1.1
+    proto_major: 1
+    proto_minor: 1
+    content_length: 16
+    body: "{\"status\": \"ok\"}"
+    headers:
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Thu, 21 Aug 2025 19:44:17 GMT
+      Server:
+      - test-server
+    status: 200 OK
+    code: 200
+    duration: 341.5µs

--- a/pkg/httpmock/testdata/server_no_additional_ignored_headers.yaml
+++ b/pkg/httpmock/testdata/server_no_additional_ignored_headers.yaml
@@ -1,0 +1,35 @@
+---
+version: 2
+interactions:
+- id: 0
+  request:
+    proto: HTTP/1.1
+    proto_major: 1
+    proto_minor: 1
+    content_length: 4
+    host: 127.0.0.1:52758
+    request_uri: /test
+    body: "null"
+    headers:
+      Content-Type:
+      - application/json
+      X-Custom:
+      - custom-value
+    url: http://127.0.0.1:52758/test
+    method: GET
+  response:
+    proto: HTTP/1.1
+    proto_major: 1
+    proto_minor: 1
+    content_length: 16
+    body: "{\"status\": \"ok\"}"
+    headers:
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Thu, 21 Aug 2025 19:41:40 GMT
+      X-Custom:
+      - response-value
+    status: 200 OK
+    code: 200
+    duration: 199.791µs


### PR DESCRIPTION
## Summary
Add a feature to `httpmock` so users can specify additional headers that should be ignored. Realized we need this after the stainless headers caused my etude in axiom to fail.

## How was it tested?
Wrote unit tests and ran them.

## Community Contribution License

All community contributions in this pull request are licensed to the project maintainers under the terms of the [Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request I represent that I have the right to license the contributions to the project maintainers under the Apache 2 License as stated in the [Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).
