### PR TITLE
Use goccy/go-yaml for yaml parsing instead of gopkg.in/yaml.v3

### DIFF
--- a/pkg/fileutil/unmarshal.go
+++ b/pkg/fileutil/unmarshal.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/pelletier/go-toml/v2"
 	"github.com/tailscale/hujson"
-	"gopkg.in/yaml.v3"
+	"github.com/goccy/go-yaml"
 )
 
 var ErrUnsupportedFormat = errors.New("unsupported file format")

--- a/pkg/fileutil/unmarshal.go
+++ b/pkg/fileutil/unmarshal.go
@@ -9,9 +9,9 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/goccy/go-yaml"
 	"github.com/pelletier/go-toml/v2"
 	"github.com/tailscale/hujson"
-	"github.com/goccy/go-yaml"
 )
 
 var ErrUnsupportedFormat = errors.New("unsupported file format")

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/coreos/go-oidc/v3 v3.15.0
 	github.com/fatih/color v1.18.0
 	github.com/go-jose/go-jose/v4 v4.1.2
+	github.com/goccy/go-yaml v1.18.0
 	github.com/google/go-github/v74 v74.0.0
 	github.com/google/renameio/v2 v2.0.0
 	github.com/gosimple/slug v1.15.0
@@ -29,13 +30,11 @@ require (
 	golang.org/x/sys v0.35.0
 	google.golang.org/protobuf v1.36.7
 	gopkg.in/dnaeon/go-vcr.v4 v4.0.5
-	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
 	github.com/arduino/go-paths-helper v1.13.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/goccy/go-yaml v1.18.0 // indirect
 	github.com/gofrs/uuid/v5 v5.3.2 // indirect
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
@@ -51,4 +50,5 @@ require (
 	github.com/spf13/pflag v1.0.7 // indirect
 	github.com/ulikunitz/xz v0.5.12 // indirect
 	golang.org/x/crypto v0.41.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/pkg/try/marshal.go
+++ b/pkg/try/marshal.go
@@ -57,3 +57,14 @@ func (r *Try[T]) UnmarshalJSON(data []byte) error {
 func (r Try[T]) MarshalYAML() (any, error) {
 	return r.toEncoding(), nil
 }
+
+// UnmarshalYAML deserializes from YAML into a Try. It expects either
+// value: ... or error: ...
+func (r *Try[T]) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var enc encodedTry[T]
+	if err := unmarshal(&enc); err != nil {
+		return err
+	}
+	*r = fromEncoding(enc)
+	return nil
+}

--- a/pkg/try/marshal.go
+++ b/pkg/try/marshal.go
@@ -3,8 +3,6 @@ package try
 import (
 	"encoding/json"
 	"errors"
-
-	"gopkg.in/yaml.v3"
 )
 
 type encodedTry[T any] struct {
@@ -58,14 +56,4 @@ func (r *Try[T]) UnmarshalJSON(data []byte) error {
 // MarshalYAML serializes the Try into YAML.
 func (r Try[T]) MarshalYAML() (any, error) {
 	return r.toEncoding(), nil
-}
-
-// UnmarshalYAML deserializes from YAML into a Try.
-func (r *Try[T]) UnmarshalYAML(value *yaml.Node) error {
-	var enc encodedTry[T]
-	if err := value.Decode(&enc); err != nil {
-		return err
-	}
-	*r = fromEncoding(enc)
-	return nil
 }

--- a/pkg/try/marshal_test.go
+++ b/pkg/try/marshal_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"github.com/goccy/go-yaml"
 )
 
 type encoder interface {
@@ -186,4 +186,6 @@ func (e *jsonEncoder) Unmarshal(data []byte, v any) error { return json.Unmarsha
 type yamlEncoder struct{}
 
 func (e *yamlEncoder) Marshal(v any) ([]byte, error)      { return yaml.Marshal(v) }
-func (e *yamlEncoder) Unmarshal(data []byte, v any) error { return yaml.Unmarshal(data, v) }
+func (e *yamlEncoder) Unmarshal(data []byte, v any) error { 
+	return yaml.UnmarshalWithOptions(data, v, yaml.UseJSONUnmarshaler())
+}

--- a/pkg/try/marshal_test.go
+++ b/pkg/try/marshal_test.go
@@ -5,9 +5,9 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/goccy/go-yaml"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/goccy/go-yaml"
 )
 
 type encoder interface {
@@ -185,7 +185,7 @@ func (e *jsonEncoder) Unmarshal(data []byte, v any) error { return json.Unmarsha
 
 type yamlEncoder struct{}
 
-func (e *yamlEncoder) Marshal(v any) ([]byte, error)      { return yaml.Marshal(v) }
-func (e *yamlEncoder) Unmarshal(data []byte, v any) error { 
+func (e *yamlEncoder) Marshal(v any) ([]byte, error) { return yaml.Marshal(v) }
+func (e *yamlEncoder) Unmarshal(data []byte, v any) error {
 	return yaml.UnmarshalWithOptions(data, v, yaml.UseJSONUnmarshaler())
 }

--- a/typeid/typeid-go/encoding_test.go
+++ b/typeid/typeid-go/encoding_test.go
@@ -5,10 +5,10 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/goccy/go-yaml"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.jetify.com/typeid/v2"
-	"github.com/goccy/go-yaml"
 )
 
 //go:embed testdata/valid.yml

--- a/typeid/typeid-go/encoding_test.go
+++ b/typeid/typeid-go/encoding_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.jetify.com/typeid/v2"
-	"gopkg.in/yaml.v3"
+	"github.com/goccy/go-yaml"
 )
 
 //go:embed testdata/valid.yml

--- a/typeid/typeid-go/go.mod
+++ b/typeid/typeid-go/go.mod
@@ -3,9 +3,9 @@ module go.jetify.com/typeid/v2
 go 1.24.0
 
 require (
+	github.com/goccy/go-yaml v1.18.0
 	github.com/gofrs/uuid/v5 v5.3.2
 	github.com/stretchr/testify v1.10.0
-	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -14,4 +14,5 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/typeid/typeid-go/go.sum
+++ b/typeid/typeid-go/go.sum
@@ -1,6 +1,8 @@
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/goccy/go-yaml v1.18.0 h1:8W7wMFS12Pcas7KU+VVkaiCng+kG8QiFeFwzFb+rwuw=
+github.com/goccy/go-yaml v1.18.0/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
 github.com/gofrs/uuid/v5 v5.3.2 h1:2jfO8j3XgSwlz/wHqemAEugfnTlikAYHhnqQ8Xh4fE0=
 github.com/gofrs/uuid/v5 v5.3.2/go.mod h1:CDOjlDMVAtN56jqyRUZh58JT31Tiw7/oQyEXZV+9bD8=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=

--- a/typeid/typeid-go/sql_test.go
+++ b/typeid/typeid-go/sql_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.jetify.com/typeid/v2"
-	"gopkg.in/yaml.v3"
+	"github.com/goccy/go-yaml"
 )
 
 //go:embed testdata/valid.yml

--- a/typeid/typeid-go/sql_test.go
+++ b/typeid/typeid-go/sql_test.go
@@ -7,10 +7,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/goccy/go-yaml"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.jetify.com/typeid/v2"
-	"github.com/goccy/go-yaml"
 )
 
 //go:embed testdata/valid.yml

--- a/typeid/typeid-go/typeid_test.go
+++ b/typeid/typeid-go/typeid_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.jetify.com/typeid/v2"
-	"gopkg.in/yaml.v3"
+	"github.com/goccy/go-yaml"
 )
 
 // TestHasSuffix tests the HasSuffix method for various TypeID values

--- a/typeid/typeid-go/typeid_test.go
+++ b/typeid/typeid-go/typeid_test.go
@@ -4,11 +4,11 @@ import (
 	_ "embed"
 	"testing"
 
+	"github.com/goccy/go-yaml"
 	"github.com/gofrs/uuid/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.jetify.com/typeid/v2"
-	"github.com/goccy/go-yaml"
 )
 
 // TestHasSuffix tests the HasSuffix method for various TypeID values


### PR DESCRIPTION
## Summary
Use goccy/go-yaml for yaml parsing instead of gopkg.in/yaml.v3

## How was it tested?
Ran all unit tests

## Community Contribution License

All community contributions in this pull request are licensed to the project maintainers under the terms of the [Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request I represent that I have the right to license the contributions to the project maintainers under the Apache 2 License as stated in the [Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).
