### PR TITLE
Remove RedactedReasoning from code

### DIFF
--- a/aisdk/ai/aitesting/aitesting.go
+++ b/aisdk/ai/aitesting/aitesting.go
@@ -142,10 +142,6 @@ func contentBlocksEqual(testingT T, expected, actual api.ContentBlock) bool {
 		if actualBlock, ok := actual.(*api.ReasoningBlock); ok {
 			return reasoningBlocksEqual(testingT, expectedBlock, actualBlock)
 		}
-	case *api.RedactedReasoningBlock:
-		if actualBlock, ok := actual.(*api.RedactedReasoningBlock); ok {
-			return redactedReasoningBlocksEqual(testingT, expectedBlock, actualBlock)
-		}
 	case *api.ImageBlock:
 		if actualBlock, ok := actual.(*api.ImageBlock); ok {
 			return imageBlocksEqual(testingT, expectedBlock, actualBlock)
@@ -191,18 +187,6 @@ func reasoningBlocksEqual(testingT T, expected, actual *api.ReasoningBlock) bool
 	// Only check signature if it's set in expected
 	if expected.Signature != "" {
 		if !assert.Equal(testingT, expected.Signature, actual.Signature, "ReasoningBlock.Signature mismatch") {
-			allMatch = false
-		}
-	}
-	return allMatch
-}
-
-// redactedReasoningBlocksEqual compares two redacted reasoning blocks using contains semantics
-func redactedReasoningBlocksEqual(testingT T, expected, actual *api.RedactedReasoningBlock) bool {
-	allMatch := true
-	// Only check data if it's set in expected
-	if expected.Data != "" {
-		if !assert.Equal(testingT, expected.Data, actual.Data, "RedactedReasoningBlock.Data mismatch") {
 			allMatch = false
 		}
 	}

--- a/aisdk/ai/aitesting/aitesting_test.go
+++ b/aisdk/ai/aitesting/aitesting_test.go
@@ -273,15 +273,23 @@ func TestResponseContains(t *testing.T) {
 			name: "matching redacted reasoning blocks",
 			expected: &api.Response{
 				Content: []api.ContentBlock{
-					&api.RedactedReasoningBlock{
-						Data: "redacted_data_123",
+					&api.ReasoningBlock{
+						Text: "", // Empty text for redacted reasoning
+						ProviderMetadata: api.NewProviderMetadata(map[string]any{
+							"anthropic": &api.ProviderMetadata{},
+						}),
 					},
 				},
 			},
 			contains: &api.Response{
 				Content: []api.ContentBlock{
-					&api.RedactedReasoningBlock{
-						Data: "redacted_data_123",
+					&api.ReasoningBlock{
+						Text: "", // Empty text for redacted reasoning
+						ProviderMetadata: api.NewProviderMetadata(map[string]any{
+							"anthropic": map[string]any{
+								"redacted_data": "redacted_data_123",
+							},
+						}),
 					},
 				},
 			},

--- a/aisdk/ai/api/llm_events.go
+++ b/aisdk/ai/api/llm_events.go
@@ -25,9 +25,6 @@ const (
 	// EventReasoningSignature represents a signature that verifies reasoning content.
 	EventReasoningSignature EventType = "reasoning-signature"
 
-	// EventRedactedReasoning represents redacted reasoning data.
-	EventRedactedReasoning EventType = "redacted-reasoning"
-
 	// EventSource represents a citation that was used to generate the response.
 	EventSource EventType = "source"
 
@@ -87,16 +84,6 @@ type ReasoningSignatureEvent struct {
 }
 
 func (b *ReasoningSignatureEvent) Type() EventType { return EventReasoningSignature }
-
-// RedactedReasoningEvent represents an update to redacted reasoning data.
-//
-// Used to update the data field of a RedactedReasoningBlock.
-type RedactedReasoningEvent struct {
-	// Data contains redacted reasoning data
-	Data string `json:"data"`
-}
-
-func (b *RedactedReasoningEvent) Type() EventType { return EventRedactedReasoning }
 
 // SourceEvent represents a source that was used to generate the response.
 //

--- a/aisdk/ai/api/llm_prompt_test.go
+++ b/aisdk/ai/api/llm_prompt_test.go
@@ -147,10 +147,10 @@ func TestUserMessage_JSON(t *testing.T) {
 						}
 					},
 					{
-						"type": "redacted-reasoning",
-						"data": "redacted_reasoning_data_xyz789",
+						"type": "reasoning",
 						"provider_metadata": {
 							"anthropic": {
+								"redacted_data": "redacted_reasoning_data_xyz789",
 								"redaction_level": "high"
 							}
 						}
@@ -277,10 +277,10 @@ func TestAssistantMessage_JSON(t *testing.T) {
 						}
 					},
 					{
-						"type": "redacted-reasoning",
-						"data": "redacted_assistant_reasoning_abc123",
+						"type": "reasoning",
 						"provider_metadata": {
 							"anthropic": {
+								"redacted_data": "redacted_assistant_reasoning_abc123",
 								"redaction_level": "medium",
 								"redaction_reason": "privacy"
 							}

--- a/aisdk/ai/builder/builder.go
+++ b/aisdk/ai/builder/builder.go
@@ -76,8 +76,6 @@ func (b *ResponseBuilder) AddEvent(event api.StreamEvent) error {
 		return b.addReasoning(evt)
 	case *api.ReasoningSignatureEvent:
 		return b.addReasoningSignature(evt)
-	case *api.RedactedReasoningEvent:
-		return b.addRedactedReasoning(evt)
 	case *api.ToolCallEvent:
 		return b.addToolCall(evt)
 	case *api.ToolCallDeltaEvent:
@@ -152,20 +150,6 @@ func (b *ResponseBuilder) addReasoningSignature(e *api.ReasoningSignatureEvent) 
 		return nil
 	}
 	return fmt.Errorf("cannot add reasoning signature: last block is not a reasoning block")
-}
-
-// addRedactedReasoning adds a redacted reasoning event to the response.
-func (b *ResponseBuilder) addRedactedReasoning(e *api.RedactedReasoningEvent) error {
-	// Validate state transition
-	if b.currentState != noState && b.currentState != reasoningState {
-		return fmt.Errorf("invalid state transition: cannot add redacted reasoning in state %v", b.currentState)
-	}
-
-	b.currentState = reasoningState
-	b.resp.Content = append(b.resp.Content, &api.RedactedReasoningBlock{
-		Data: e.Data,
-	})
-	return nil
 }
 
 // addToolCall adds a tool call event to the response.

--- a/aisdk/ai/builder/builder_test.go
+++ b/aisdk/ai/builder/builder_test.go
@@ -87,16 +87,12 @@ func TestResponseBuilder(t *testing.T) {
 			events: []api.StreamEvent{
 				&api.ReasoningEvent{TextDelta: "Let's think about this"},
 				&api.ReasoningSignatureEvent{Signature: "sig123"},
-				&api.RedactedReasoningEvent{Data: "redacted_data"},
 			},
 			expected: &api.Response{
 				Content: []api.ContentBlock{
 					&api.ReasoningBlock{
 						Text:      "Let's think about this",
 						Signature: "sig123",
-					},
-					&api.RedactedReasoningBlock{
-						Data: "redacted_data",
 					},
 				},
 			},

--- a/aisdk/ai/provider/anthropic/codec/decode.go
+++ b/aisdk/ai/provider/anthropic/codec/decode.go
@@ -100,7 +100,7 @@ func decodeToolUse(block anthropic.BetaContentBlockUnion) *api.ToolCallBlock {
 }
 
 // decodeReasoning converts an Anthropic thinking block to an AI SDK ReasoningBlock
-func decodeReasoning(block anthropic.BetaContentBlockUnion) api.Reasoning {
+func decodeReasoning(block anthropic.BetaContentBlockUnion) *api.ReasoningBlock {
 	switch block.Type {
 	case "thinking":
 		// Check for nil or empty thinking text
@@ -116,8 +116,15 @@ func decodeReasoning(block anthropic.BetaContentBlockUnion) api.Reasoning {
 		if block.Data == "" {
 			return nil
 		}
-		return &api.RedactedReasoningBlock{
-			Data: block.Data,
+		// Create ReasoningBlock with redacted data in provider metadata
+		metadata := api.NewProviderMetadata(map[string]any{
+			"anthropic": &Metadata{
+				RedactedData: block.Data,
+			},
+		})
+		return &api.ReasoningBlock{
+			Text:             "", // Empty text for redacted reasoning
+			ProviderMetadata: metadata,
 		}
 	}
 	return nil

--- a/aisdk/ai/provider/anthropic/codec/decode_test.go
+++ b/aisdk/ai/provider/anthropic/codec/decode_test.go
@@ -172,7 +172,7 @@ func TestDecodeReasoning(t *testing.T) {
 	tests := []struct {
 		name  string
 		block anthropic.BetaContentBlockUnion
-		want  api.Reasoning
+		want  *api.ReasoningBlock
 	}{
 		{
 			name: "thinking block",
@@ -192,8 +192,13 @@ func TestDecodeReasoning(t *testing.T) {
 				Type: "redacted_thinking",
 				Data: "redacted-data",
 			},
-			want: &api.RedactedReasoningBlock{
-				Data: "redacted-data",
+			want: &api.ReasoningBlock{
+				Text: "", // Empty text for redacted reasoning
+				ProviderMetadata: api.NewProviderMetadata(map[string]any{
+					"anthropic": &Metadata{
+						RedactedData: "redacted-data",
+					},
+				}),
 			},
 		},
 		{

--- a/aisdk/ai/provider/anthropic/codec/metadata.go
+++ b/aisdk/ai/provider/anthropic/codec/metadata.go
@@ -15,6 +15,9 @@ type Metadata struct {
 
 	Thinking ThinkingConfig `json:"thinking,omitzero"`
 	Usage    Usage          `json:"usage,omitempty"`
+
+	// RedactedData contains redacted reasoning data when reasoning blocks are redacted
+	RedactedData string `json:"redacted_data,omitempty"`
 }
 
 func GetMetadata(source api.MetadataSource) *Metadata {

--- a/aisdk/ai/provider/openai/internal/codec/decode.go
+++ b/aisdk/ai/provider/openai/internal/codec/decode.go
@@ -98,7 +98,7 @@ func decodeContent(msg *responses.Response) (responseContent, error) {
 }
 
 // decodeReasoning processes a reasoning output item and returns a reasoning block
-func decodeReasoning(item responses.ResponseOutputItemUnion) (api.Reasoning, error) {
+func decodeReasoning(item responses.ResponseOutputItemUnion) (*api.ReasoningBlock, error) {
 	if item.Type != "reasoning" {
 		return nil, fmt.Errorf("unexpected item type for reasoning: %s", item.Type)
 	}

--- a/aisdk/ai/provider/openai/internal/codec/decode_test.go
+++ b/aisdk/ai/provider/openai/internal/codec/decode_test.go
@@ -1142,7 +1142,7 @@ func TestDecodeReasoning(t *testing.T) {
 	tests := []struct {
 		name    string
 		input   string
-		want    api.Reasoning
+		want    *api.ReasoningBlock
 		wantErr string
 	}{
 		{


### PR DESCRIPTION
## Summary
Simplify the API by removing the need for "RedactedReasoning". Instead we have a single Reasoning block, and if there's fields related to a redaction, we keep them in the provider metadata.

This follows the recent changes in the Vercel SDK.

## How was it tested?
Updated tests and ran them.

## Community Contribution License

All community contributions in this pull request are licensed to the project maintainers under the terms of the [Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request I represent that I have the right to license the contributions to the project maintainers under the Apache 2 License as stated in the [Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).
