### PR TITLE
[aisdk] add Truncation: {auto, default} as an encoding metadata option

### DIFF
--- a/aisdk/ai/provider/openai/internal/codec/metadata.go
+++ b/aisdk/ai/provider/openai/internal/codec/metadata.go
@@ -66,6 +66,16 @@ type Metadata struct {
 	// Supported values are `concise` and `detailed`.
 	ReasoningSummary string `json:"reasoning_summary,omitempty"`
 
+	// Truncation specifies the truncation strategy to use for the model input.
+	// When set, this overrides any model-specific default truncation behavior.
+	//
+	// Supported values are `auto` and `disabled` (default).
+	// - `auto`: If the context of this response and previous ones exceeds the
+	//   model's context window size, the model will truncate the response to fit.
+	// - `disabled`: If the context exceeds the model's context window size,
+	//   the request will fail with a 400 error.
+	Truncation string `json:"truncation,omitempty"`
+
 	// --- Used in blocks ---
 
 	// ImageDetail indicates the level of detail that should be used when processing


### PR DESCRIPTION
## Summary

In `getModelConfig`, we specify some default settings for the openai models.
In particular, the RequiredAutoTruncation is hardcoded in there.

Some users may want to override this and manually set the truncation to auto or disabled, depending on their specific use-case.
This PR allows that.

## How was it tested?

Did not do any rigorous testing aside from compiling, and code inspection.
We can consider adding some test-cases here in the future.

## Community Contribution License

All community contributions in this pull request are licensed to the project maintainers under the terms of the [Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request I represent that I have the right to license the contributions to the project maintainers under the Apache 2 License as stated in the [Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).
